### PR TITLE
[Fix] 프로필 사진 미등록 시 기본 프로필 이미지 등록(#23)

### DIFF
--- a/src/main/java/com/team1/moim/domain/auth/service/AuthService.java
+++ b/src/main/java/com/team1/moim/domain/auth/service/AuthService.java
@@ -52,6 +52,8 @@ public class AuthService {
         String imageUrl = null;
         if (request.getProfileImage() != null && !request.getProfileImage().isEmpty()){
             imageUrl = s3Service.uploadFile(FILE_TYPE, request.getProfileImage());
+        } else {
+            imageUrl = s3Service.getDefaultImage(FILE_TYPE);
         }
         Member newMember = request.toEntity(passwordEncoder, Role.ROLE_USER, imageUrl);
 

--- a/src/main/java/com/team1/moim/global/config/s3/S3Service.java
+++ b/src/main/java/com/team1/moim/global/config/s3/S3Service.java
@@ -64,6 +64,11 @@ public class S3Service {
         return amazonS3Client.getUrl(bucket, keyName).toString();
     }
 
+    public String getDefaultImage(String fileType){
+        String keyName =  fileType + "/" + "default_profile.png";
+        return getUrl(keyName);
+    }
+
     // UUID 파일명 반환
     public String getUuidFileName(String fileName){
         String ext = fileName.substring(fileName.indexOf(".") + 1);


### PR DESCRIPTION
## #️⃣연관된 이슈
* #23 

## 📝작업한 내용
1. S3에 기본 프로필 이미지 업로드
2. 기본 프로필 이미지 경로 가져오는 함수 추가
3. 회원 가입 로직 수정

![image](https://github.com/HanHwa-Team1-Final-Project/Team1-BE/assets/60949121/91460378-b3f9-4951-81ed-24eaa7827309)
![image](https://github.com/HanHwa-Team1-Final-Project/Team1-BE/assets/60949121/eb1ebe52-3173-454b-b276-baa0ba571454)

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정
- [x] 기능 추가