### PR TITLE
[Feat] 소셜 로그인 구현(#7)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	// JWT 관련 라이브러리
 	implementation 'com.auth0:java-jwt:4.2.1'

--- a/src/main/java/com/team1/moim/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/team1/moim/domain/auth/dto/request/SignUpRequest.java
@@ -23,12 +23,19 @@ public class SignUpRequest {
     private MultipartFile profileImage;
 
     public Member toEntity(PasswordEncoder passwordEncoder, Role role, String imageUrl){
+        String finalPassword = null;
+        if (password != null){
+            finalPassword = passwordEncoder.encode(password);
+        }
+
         return Member.builder()
                 .email(email)
-                .password(passwordEncoder.encode(password))
+                .password(finalPassword)
                 .nickname(nickname)
                 .profileImage(imageUrl)
                 .role(role)
+                .socialType(null)
+                .socialId(null)
                 .build();
     }
 }

--- a/src/main/java/com/team1/moim/domain/member/entity/Member.java
+++ b/src/main/java/com/team1/moim/domain/member/entity/Member.java
@@ -33,16 +33,24 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType = null;
+
+    private String socialId = null; // 로그인 한 소셜 타입의 식별자 값 (일반 로그인은 null)
+
     @Column(nullable = false)
     private String deleteYn = "N";
 
     @Builder
-    public Member(String email, String password, String nickname, String profileImage, Role role) {
+    public Member(String email, String password, String nickname,
+                  String profileImage, Role role, SocialType socialType, String socialId) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.role = role;
+        this.socialType = socialType;
+        this.socialId = socialId;
     }
 
     public void withdraw() {

--- a/src/main/java/com/team1/moim/domain/member/entity/SocialType.java
+++ b/src/main/java/com/team1/moim/domain/member/entity/SocialType.java
@@ -1,0 +1,5 @@
+package com.team1.moim.domain.member.entity;
+
+public enum SocialType {
+    KAKAO, GOOGLE
+}

--- a/src/main/java/com/team1/moim/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/team1/moim/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.team1.moim.domain.member.repository;
 
 import com.team1.moim.domain.member.entity.Member;
+import com.team1.moim.domain.member.entity.SocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +12,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByNickname(String nickname);
     Optional<Member> findByEmail(String email);
     Optional<Member> findByRefreshToken(String refreshToken);
+    Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
 }

--- a/src/main/java/com/team1/moim/global/config/security/login/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/team1/moim/global/config/security/login/handler/LoginSuccessHandler.java
@@ -34,6 +34,7 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
                                         Authentication authentication) throws IOException {
+        log.info("onAuthenticationSuccess() 진입");
         String email = extractUsername(authentication); // 인증 정보에서 Username(email) 추출
         String role = memberRepository.findByEmail(email)
                 .orElseThrow(MemberNotFoundException::new)
@@ -55,6 +56,7 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     }
 
     private String extractUsername(Authentication authentication){
+        log.info("extractUsername() 진입");
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         return userDetails.getUsername();
     }

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/CustomOAuth2User.java
@@ -1,0 +1,24 @@
+package com.team1.moim.global.config.security.oauth2;
+
+import com.team1.moim.domain.member.entity.Role;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User extends DefaultOAuth2User {
+
+    private final String email;
+    private final Role role;
+
+    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
+                            Map<String, Object> attributes, String nameAttributeKey,
+                            String email, Role role){
+        super(authorities, attributes, nameAttributeKey);
+        this.email = email;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/OAuthAttributes.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/OAuthAttributes.java
@@ -1,0 +1,77 @@
+package com.team1.moim.global.config.security.oauth2;
+
+import com.team1.moim.domain.member.entity.Member;
+import com.team1.moim.domain.member.entity.Role;
+import com.team1.moim.domain.member.entity.SocialType;
+import com.team1.moim.global.config.security.oauth2.userinfo.GoogleOAuth2UserInfo;
+import com.team1.moim.global.config.security.oauth2.userinfo.KakaoOAuth2UserInfo;
+import com.team1.moim.global.config.security.oauth2.userinfo.OAuth2UserInfo;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 각 소셜에서 받아오는 데이터가 다르므로,
+ * 소셜 별로 데이터를 받은 데이터를 분기 처리하는 DTO 클래스
+ */
+
+@Getter
+public class OAuthAttributes {
+
+    private String nameAttributeKey; // OAuth2 로그인 진행 시 키가 되는 필드 값, PK와 동일
+    private OAuth2UserInfo oAuth2UserInfo; // 소셜 타입별 로그인 유저 정보 (nickname, email, profile_image 등)
+
+    @Builder
+    private OAuthAttributes(String nameAttributeKey, OAuth2UserInfo oauth2UserInfo){
+        this.nameAttributeKey = nameAttributeKey;
+        this.oAuth2UserInfo = oauth2UserInfo;
+    }
+
+    /**
+     * SocialType에 맞는 메소드 호출하여 OAuthAttributes 객체 반환
+     * @param userNameAttributeName: OAuth2 로그인 시 키(PK)가 되는 값
+     * @param attributes: OAuth 서비스의 유저 정보들
+     */
+    public static OAuthAttributes of(SocialType socialType,
+                                     String userNameAttributeName,
+                                     Map<String, Object> attributes){
+
+        if (socialType == SocialType.GOOGLE) {
+            return ofGoogle(userNameAttributeName, attributes);
+        }
+
+        return ofKakao(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName,
+                                            Map<String, Object> attributes){
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new GoogleOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    private static OAuthAttributes ofKakao(String userNameAttributeName,
+                                            Map<String, Object> attributes){
+        return OAuthAttributes.builder()
+                .nameAttributeKey(userNameAttributeName)
+                .oauth2UserInfo(new KakaoOAuth2UserInfo(attributes))
+                .build();
+    }
+
+    // of메소드로 OAuthAttributes 객체가 생성되어, 유저 정보들이 담긴 OAuth2UserInfo가 소셜 타입별로 주입된 상태
+    public Member toEntity(SocialType socialType, OAuth2UserInfo oAuth2UserInfo){
+        return Member.builder()
+                .socialType(socialType)
+                .socialId(oAuth2UserInfo.getId())
+                // email은 JWT Token을 발급하기 위한 용도뿐이므로 UUID를 사용하여 임의로 설정
+                .email(UUID.randomUUID() + "@socialMember.com")
+                .nickname(oAuth2UserInfo.getNickname())
+                .profileImage(oAuth2UserInfo.getImageUrl())
+                .role(Role.USER)
+                .build();
+    }
+
+}

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,26 @@
+package com.team1.moim.global.config.security.oauth2.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().write("소셜 로그인 실패, 서버 로그 확인 필요");
+        log.info("소셜 로그인에 실패했습니다. 에러 메시지 : {}", exception.getMessage());
+    }
+}

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,49 @@
+package com.team1.moim.global.config.security.oauth2.handler;
+
+import com.team1.moim.domain.member.repository.MemberRepository;
+import com.team1.moim.global.config.security.jwt.JwtProvider;
+import com.team1.moim.global.config.security.oauth2.CustomOAuth2User;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtProvider jwtProvider;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        log.info("OAuth2 Login 성공");
+        try {
+            CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+            loginSuccess(response, oAuth2User); // 로그인에 성공한 경우 access, refresh 토큰 생성
+        } catch (Exception e){
+            log.error("OAuth2 Login 실패: {}", e.getMessage());
+        }
+    }
+
+    // 소셜 로그인 시에도 무조건 토큰 생성하지 말고 JWT 인증 필터처럼 RefreshToken 유/무에 따라 다르게 처리
+    private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
+        log.info("loginSuccess 진입");
+        String accessToken = jwtProvider.createAccessToken(oAuth2User.getEmail(), oAuth2User.getRole().name());
+        String refreshToken = jwtProvider.createRefreshToken();
+        response.addHeader(jwtProvider.getAccessHeader(), "Bearer " + accessToken);
+        response.addHeader(jwtProvider.getRefreshHeader(), "Bearer " + refreshToken);
+
+        jwtProvider.sendAccessAndRefreshToken(response, accessToken, refreshToken);
+        jwtProvider.updateRefreshToken(oAuth2User.getEmail(), refreshToken);
+    }
+}

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/handler/Oauth2LoginFailureHandler.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/handler/Oauth2LoginFailureHandler.java
@@ -1,4 +1,0 @@
-package com.team1.moim.global.config.security.oauth2.handler;
-
-public class Oauth2LoginFailureHandler {
-}

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/handler/Oauth2LoginSuccessHandler.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/handler/Oauth2LoginSuccessHandler.java
@@ -1,4 +1,0 @@
-package com.team1.moim.global.config.security.oauth2.handler;
-
-public class Oauth2LoginSuccessHandler {
-}

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,102 @@
+package com.team1.moim.global.config.security.oauth2.service;
+
+import com.team1.moim.domain.member.entity.Member;
+import com.team1.moim.domain.member.entity.SocialType;
+import com.team1.moim.domain.member.repository.MemberRepository;
+import com.team1.moim.global.config.security.oauth2.CustomOAuth2User;
+import com.team1.moim.global.config.security.oauth2.OAuthAttributes;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final MemberRepository memberRepository;
+
+    private static final String KAKAO = "kakao";
+
+    // 소셜 로그인 API의 사용자 정보 제공 URI로 요청을 보내서
+    // 사용자 정보를 얻은 후, 이를 통해 DefaultOAuth2User 객체를 생성 후 반환
+    // 결과적으로, OAuth2User는 OAuth 서비스에서 가져온 유저 정보를 담고 있는 유저
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        log.info("CustomOAuth2UserService.loadUser() 실행 - OAuth2 로그인 요청 진입");
+
+        // DefaultOAuth2UserService 객체를 생성하여, loadUser(userRequest)를 통해 DefaultOAuth2User 객체를 생성 후 반환
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+        log.info("1");
+
+        // registrationId 추출 후 이 Id로 SocialType 구해서 저장
+        // http://localhost:8080/oauth2/authorization/kakao에서 kakao가 registrationId
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        log.info("2");
+        SocialType socialType = getSocialType(registrationId);
+        log.info("3 / socialType: {}", socialType);
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails()
+                .getUserInfoEndpoint()
+                .getUserNameAttributeName(); // OAuth2 로그인 시 키(PK)가 되는 값
+        log.info("4 / userNameAttributeName: {}", userNameAttributeName);
+
+        // 소셜 로그인에서 API가 제공하는 userInfo의 Json 값(유저 정보들)
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        log.info("5 / attributes: {}", attributes);
+
+        // SocialType에 따라 유저 정보를 통해 OAuthAttributes 객체 생성
+        OAuthAttributes extractAttributes = OAuthAttributes.of(socialType, userNameAttributeName, attributes);
+        log.info("6 / extractAttributes: {}", extractAttributes);
+
+        Member createdMember = getMember(extractAttributes, socialType);
+        log.info("7 / createdMember: {}", createdMember);
+
+        return new CustomOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(createdMember.getRole().name())),
+                attributes,
+                extractAttributes.getNameAttributeKey(),
+                createdMember.getEmail(),
+                createdMember.getRole());
+    }
+
+    private SocialType getSocialType(String registrationId) {
+        if (registrationId.equals(KAKAO)){
+            return SocialType.KAKAO;
+        }
+        return SocialType.GOOGLE;
+    }
+
+    // SocialType과 attributes에 들어있는 소셜 로그인의 식별값 id를 통해 회원을 찾아 반환
+    // 만약 찾은 회원이 있다면 그대로 반환하고, 없다면 saveUser()를 호출하여 회원을 저장
+    private Member getMember(OAuthAttributes attributes, SocialType socialType){
+        Member findMember = memberRepository.findBySocialTypeAndSocialId(socialType,
+                attributes.getOAuth2UserInfo().getId()).orElse(null);
+
+        if (findMember == null){
+            return saveMember(attributes, socialType);
+        }
+
+        return findMember;
+    }
+
+    // 생성된 Member 객체를 DB에 저장 : socialType, socialId, email, role 값만 있는 상태
+    private Member saveMember(OAuthAttributes attributes, SocialType socialType){
+
+        Member createdMember = attributes.toEntity(socialType, attributes.getOAuth2UserInfo());
+
+        return memberRepository.save(createdMember);
+    }
+
+}

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/userinfo/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/userinfo/GoogleOAuth2UserInfo.java
@@ -1,0 +1,25 @@
+package com.team1.moim.global.config.security.oauth2.userinfo;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo{
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("picture");
+    }
+}

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/userinfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/userinfo/KakaoOAuth2UserInfo.java
@@ -1,0 +1,51 @@
+package com.team1.moim.global.config.security.oauth2.userinfo;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo{
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes){
+        super(attributes);
+    }
+
+    @Override
+    public String getId(){
+        return String.valueOf(attributes.get("id"));
+    }
+
+    // 유저 정보가 'kakao_account.profile'으로 2번 감싸져있는 구조
+    @Override
+    public String getNickname() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+
+        if (account == null){
+            return null;
+        }
+
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+        if (profile == null) {
+            return null;
+        }
+
+        return (String) profile.get("nickname");
+
+    }
+
+    @Override
+    public String getImageUrl() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+
+        if (account == null) {
+            return null;
+        }
+
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+        if (profile == null) {
+            return null;
+        }
+
+        return (String) profile.get("thumbnail_image_url");
+    }
+}

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/userinfo/OAuth2UserInfo.java
@@ -1,0 +1,21 @@
+package com.team1.moim.global.config.security.oauth2.userinfo;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+
+    // 추상클래스를 상속받는 클래스에서만 사용할 수 있도록 protected 제어자를 사용
+    protected Map<String, Object> attributes;
+
+    // 소셜 타입별 유저 정보 attributes를 주입받아서,
+    // 각 소셜 타입별 유저 정보 클래스가 소셜 타입에 맞는 attributes를 주입받아 가지도록 함
+    protected OAuth2UserInfo(Map<String, Object> attributes){
+        this.attributes = attributes;
+    }
+
+    // 서비스에 사용하고 싶은 유저 정보들을 가져오는 메소드를 생성
+    // 각 소셜에서 제공하는 정보 중에 사용하고 싶은 정보가 있다면 더 추가해서 사용하면 됨
+    public abstract String getId(); // 소셜 식별 값 : 구글 - "sub", 카카오 - "id"
+    public abstract String getNickname();
+    public abstract String getImageUrl();
+}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>OAuth2 Test</title>
+</head>
+<body>
+    <a href="/oauth2/authorization/kakao">Kakao Login</a><br>
+    <a href="/oauth2/authorization/google">Google Login</a><br>
+</body>
+</html>


### PR DESCRIPTION
## #️⃣연관된 이슈
* #7 

## 📝작업한 내용
1. Kakao, Google 소셜 로그인
2. Access Token, Refresh Token 적용
3. 소셜 로그인 유저는 email을 UUID로 랜덤 생성 (email이 not null 이므로)
4. index.html은 소셜 로그인 테스트용 파일

## 이미지
### 1. 소셜 로그인 테스트 페이지
![image](https://github.com/HanHwa-Team1-Final-Project/Team1-BE/assets/60949121/d05b6c52-c20c-46c7-9613-a36f26f712da)

### 2. 카카오 로그인 시도
![image](https://github.com/HanHwa-Team1-Final-Project/Team1-BE/assets/60949121/c62f7e2d-ced8-458d-8ea3-b46fde8a4c28)
![image](https://github.com/HanHwa-Team1-Final-Project/Team1-BE/assets/60949121/c4c12642-bee3-4474-bc92-c227a6a73656)

### 3. 구글 로그인 시도
![image](https://github.com/HanHwa-Team1-Final-Project/Team1-BE/assets/60949121/af17aec4-e57b-494c-95f2-f87136d45bcc)
![image](https://github.com/HanHwa-Team1-Final-Project/Team1-BE/assets/60949121/cb93b2cc-7cf9-48ee-8584-420d21d22834)
![image](https://github.com/HanHwa-Team1-Final-Project/Team1-BE/assets/60949121/a3dfd00b-b1cb-4412-803d-202869bb6c88)

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 기능 추가