### PR TITLE
[Feat/Event]메트릭스 이벤트 조회 api 추가

### DIFF
--- a/src/main/java/com/team1/moim/domain/event/controller/EventController.java
+++ b/src/main/java/com/team1/moim/domain/event/controller/EventController.java
@@ -5,6 +5,7 @@ import com.team1.moim.domain.event.dto.request.EventRequest;
 import com.team1.moim.domain.event.dto.request.RepeatRequest;
 import com.team1.moim.domain.event.dto.request.ToDoListRequest;
 import com.team1.moim.domain.event.dto.response.EventResponse;
+import com.team1.moim.domain.event.entity.Matrix;
 import com.team1.moim.domain.event.service.EventService;
 import com.team1.moim.domain.event.service.PublicHoliyDayAPI;
 import com.team1.moim.global.dto.ApiSuccessResponse;
@@ -80,7 +81,7 @@ public class EventController {
                         ("삭제되었습니다.")));
     }
 
-//   반복일정의 삭제
+    //   반복일정의 삭제
     @PreAuthorize("hasRole('ROLE_USER')")
     @DeleteMapping("/repeat/{eventId}")
     public ResponseEntity<ApiSuccessResponse<String>> deleteRepeat(HttpServletRequest servRequest,
@@ -93,7 +94,19 @@ public class EventController {
                         servRequest.getServletPath(),
                         ("삭제되었습니다.")));
     }
+    //   메트릭스 일정 조회 api
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/matrix/{matrix}")
+    public ResponseEntity<ApiSuccessResponse<List<EventResponse>>> matrixEvents(
+            HttpServletRequest servRequest,
+            @PathVariable(name = "matrix")Matrix matrix) {
 
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiSuccessResponse.of(
+                        HttpStatus.OK,
+                        servRequest.getServletPath(),
+                        eventService.matrixEvents(matrix)));
+    }
 
     @PostMapping("/getHoliday")
     public ResponseEntity<ArrayList<HashMap<String, Object>>> holidayInfoApi(String year, String month) {

--- a/src/main/java/com/team1/moim/domain/event/service/EventService.java
+++ b/src/main/java/com/team1/moim/domain/event/service/EventService.java
@@ -303,6 +303,26 @@ public class EventService {
 
         }
     }
+    
+    public List<EventResponse> matrixEvents(Matrix matrix) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        Member member = memberRepository.findByEmail(email).orElseThrow();
+        List<Event> events = eventRepository.findByMember(member);
+
+        List<EventResponse> matrixEvents = new ArrayList<>();
+        
+        for (Event event : events){
+            if(event.getMatrix().equals(matrix) && 
+                    event.getStartDateTime().isAfter(LocalDateTime.now()) && 
+                    event.getStartDateTime().isBefore(LocalDateTime.now().plusMonths(1))){
+                log.info(event.getTitle());
+                EventResponse eventResponse = EventResponse.from(event);
+                matrixEvents.add(eventResponse);
+            }
+        }
+
+        return matrixEvents;
+    }
 
     // 알림 전송 스케줄러
     @Scheduled(cron = "0 0/1 * * * *") // 매분마다 실행
@@ -341,4 +361,6 @@ public class EventService {
             }
         }
     }
+
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) * #67 

## 📝작업한 내용
> 
<img width="1030" alt="Screenshot 2024-04-09 at 4 49 12 PM" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/125184448/dbb9986f-303b-4d78-845b-81112a450194">


## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 현재날짜 기준 30일 이내의 특정 메트릭스 이벤트 전체 조회

