### PR TITLE
[Refactor/Auth] 이메일 인증 관련 코드 리팩토링, 회원가입 시 필요한 기능 추가

### DIFF
--- a/src/main/java/com/team1/moim/domain/auth/exception/CodeNotMatchException.java
+++ b/src/main/java/com/team1/moim/domain/auth/exception/CodeNotMatchException.java
@@ -1,0 +1,15 @@
+package com.team1.moim.domain.auth.exception;
+
+import com.team1.moim.global.exception.ErrorCode;
+import com.team1.moim.global.exception.MoimException;
+import lombok.Getter;
+
+@Getter
+public class CodeNotMatchException extends MoimException {
+
+    private static final ErrorCode errorcode = ErrorCode.CODE_NOT_MATCH;
+
+    public CodeNotMatchException() {
+        super(errorcode);
+    }
+}

--- a/src/main/java/com/team1/moim/domain/auth/exception/NotFoundCodeException.java
+++ b/src/main/java/com/team1/moim/domain/auth/exception/NotFoundCodeException.java
@@ -1,0 +1,15 @@
+package com.team1.moim.domain.auth.exception;
+
+import com.team1.moim.global.exception.ErrorCode;
+import com.team1.moim.global.exception.MoimException;
+import lombok.Getter;
+
+@Getter
+public class NotFoundCodeException extends MoimException {
+
+    private static final ErrorCode errorcode = ErrorCode.NOT_FOUND_CODE;
+
+    public NotFoundCodeException() {
+        super(errorcode);
+    }
+}

--- a/src/main/java/com/team1/moim/global/exception/ErrorCode.java
+++ b/src/main/java/com/team1/moim/global/exception/ErrorCode.java
@@ -12,6 +12,11 @@ public enum ErrorCode {
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     LOGIN_FAILED(HttpStatus.BAD_REQUEST, "로그인에 실패했습니다. 이메일 또는 비밀번호를 확인해주세요."),
 
+    // Auth
+    NOT_FOUND_CODE(HttpStatus.BAD_REQUEST, "발송한 인증코드가 없습니다."),
+    CODE_NOT_MATCH(HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
+
+
     // Group
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 모임입니다."),
     GROUP_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 모임 게스트입니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈
* #41 

## 📝작업한 내용
* Controller에 있는 비즈니스 로직을 Service단으로 이전
* 기존 이메일 인증 코드에 @Async 붙였을 때 발생하는 에러 해결 -> 반환값을 void로 변경
* 이메일 중복 검증
* 닉네임 중복 검증

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정
- [x] 기능 추가
- [x] 리팩토링 (기능 변경 X)