### PR TITLE
[Fix] 월별 조회 쿼리 수정

### DIFF
--- a/src/main/java/com/team1/moim/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/team1/moim/domain/event/repository/EventRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -16,8 +17,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findByRepeatParent(Long repeatParent);
     List<Event> findByMember(Member member);
 
-    @Query(value = "SELECT e FROM Event e WHERE e.member = :member AND FUNCTION('YEAR', e.startDateTime) = :year AND FUNCTION('MONTH', e.startDateTime) = :month")
-    List<Event> findByMemberAndYearAndMonth(@Param("member") Member member, @Param("year") int year, @Param("month") int month);
+    @Query("SELECT e FROM Event e WHERE e.member = :member AND (e.startDateTime <= :end AND e.endDateTime >= :start)")
+    List<Event> findByMemberAndDateRange(@Param("member") Member member, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
     @Query("SELECT e FROM Event e WHERE e.member = :member AND FUNCTION('YEAR', e.startDateTime) = :year AND FUNCTION('WEEK', e.startDateTime) = :week")
     List<Event> findByMemberAndYearAndWeek(@Param("member") Member member, @Param("year") int year, @Param("week") int week);


### PR DESCRIPTION
## #️⃣연관된 이슈
* #8 

## 📝작업한 내용
> 월별 조회 시 시작일, 종료일이 해당 월일 경우만 조회되는 문제 해결


![image](https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/112849147/c22b8dfc-4b15-4751-852a-e3b075855819)
1월로 조회 시 12월 부터 시작한 일정도 조회됨

## PR 종류
- [x] 버그 수정
