### PR TITLE
이메일, 닉네임으로 멤버 검색 기능 추가

### DIFF
--- a/src/main/java/com/team1/moim/domain/member/controller/MemberController.java
+++ b/src/main/java/com/team1/moim/domain/member/controller/MemberController.java
@@ -11,6 +11,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @Slf4j
 @RequestMapping("/api/members")
@@ -50,8 +52,19 @@ public class MemberController {
                 ));
     }
 
-//    @PostMapping
-//    public ResponseEntity
+    //멤버 검색
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/search/{content}")
+    public ResponseEntity<ApiSuccessResponse<List<MemberResponse>>> searchMember(HttpServletRequest request,
+                                                                                 @PathVariable("content") String content) {
 
+        log.info("멤버 검색 시작");
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiSuccessResponse.of(
+                        HttpStatus.OK,
+                        request.getServletPath(),
+                        memberService.searchMember(content)));
+    }
 
 }

--- a/src/main/java/com/team1/moim/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/team1/moim/domain/member/repository/MemberRepository.java
@@ -1,10 +1,14 @@
 package com.team1.moim.domain.member.repository;
 
+import com.team1.moim.domain.event.entity.Event;
 import com.team1.moim.domain.member.entity.Member;
 import com.team1.moim.domain.member.entity.SocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,4 +17,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     Optional<Member> findByRefreshToken(String refreshToken);
     Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+
+    @Query("SELECT m FROM Member m WHERE m.nickname LIKE %:content% OR m.email LIKE %:content%")
+    List<Member> findByNicknameOrEmail(@Param("content") String content);
+
+
 }

--- a/src/main/java/com/team1/moim/domain/member/service/MemberService.java
+++ b/src/main/java/com/team1/moim/domain/member/service/MemberService.java
@@ -10,6 +10,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -41,5 +44,14 @@ public class MemberService {
                 .orElseThrow(MemberNotFoundException::new);
     }
 
+    // 멤버 검색
+    public List<MemberResponse> searchMember(String content) {
+        List<Member> members = memberRepository.findByNicknameOrEmail(content);
 
+        List<MemberResponse> memberResponses = new ArrayList<>();
+        for(Member member : members){
+            memberResponses.add(MemberResponse.from(member));
+        }
+        return memberResponses;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) * #83 

## 📝작업한 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)


-  이메일로 멤버 검색: id 6번의 이메일에만 a가 들어가 검색됨
<img width="634" alt="Screenshot 2024-04-19 at 2 44 56 PM" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/125184448/507f6598-4257-49b9-aa50-15cf38b8bb17">


- 닉네임으로 멤버 검색: id 6번의 닉네임에 b가 들어가 검색됨
<img width="607" alt="Screenshot 2024-04-19 at 2 45 13 PM" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/125184448/e7a80282-ab40-4ed0-86a6-390d2cd8dfeb">


## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 닉네임과 이메일로 멤버 검색 기능 추가
