### PR TITLE
[Feat/Event] 단일 일정의 알림 조회 기능 추가 및 글자 수 이슈 해결

### DIFF
--- a/src/main/java/com/team1/moim/domain/event/controller/EventController.java
+++ b/src/main/java/com/team1/moim/domain/event/controller/EventController.java
@@ -5,6 +5,7 @@ import com.team1.moim.domain.event.dto.request.AlarmRequest;
 import com.team1.moim.domain.event.dto.request.EventRequest;
 import com.team1.moim.domain.event.dto.request.RepeatRequest;
 import com.team1.moim.domain.event.dto.request.ToDoListRequest;
+import com.team1.moim.domain.event.dto.response.AlarmResponse;
 import com.team1.moim.domain.event.dto.response.EventResponse;
 import com.team1.moim.domain.event.entity.Matrix;
 import com.team1.moim.domain.event.service.EventService;
@@ -12,18 +13,24 @@ import com.team1.moim.domain.event.service.PublicHoliyDayAPI;
 import com.team1.moim.global.dto.ApiSuccessResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -231,6 +238,17 @@ public class EventController {
                         eventService.searchEvent(content)));
     }
 
-
-
+    // 단일 일정의 알림 조회
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/search/alarm/{event_id}")
+    public ResponseEntity<ApiSuccessResponse<List<AlarmResponse>>> searchAlarm(
+            HttpServletRequest httpServletRequest, @PathVariable("event_id") Long eventId) {
+        log.info("단일 일정의 알림 조회 시작");
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiSuccessResponse.of(
+                        HttpStatus.OK,
+                        httpServletRequest.getServletPath(),
+                        eventService.findAlarmByEventId(eventId)));
+    }
 }

--- a/src/main/java/com/team1/moim/domain/event/entity/Event.java
+++ b/src/main/java/com/team1/moim/domain/event/entity/Event.java
@@ -1,17 +1,26 @@
 package com.team1.moim.domain.event.entity;
 
-import com.team1.moim.domain.group.entity.GroupInfo;
 import com.team1.moim.domain.member.entity.Member;
 import com.team1.moim.global.config.BaseTimeEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -27,7 +36,7 @@ public class Event extends BaseTimeEntity{
     private String title;
 
 //    내용
-    @Column(nullable = false)
+    @Column(length=1000)
     private String memo;
 
 //    시작일자

--- a/src/main/java/com/team1/moim/domain/event/exception/AlarmNotFoundException.java
+++ b/src/main/java/com/team1/moim/domain/event/exception/AlarmNotFoundException.java
@@ -1,0 +1,15 @@
+package com.team1.moim.domain.event.exception;
+
+import com.team1.moim.global.exception.ErrorCode;
+import com.team1.moim.global.exception.MoimException;
+import lombok.Getter;
+
+@Getter
+public class AlarmNotFoundException extends MoimException {
+
+    private static final ErrorCode errorCode = ErrorCode.ALARM_NOT_FOUND;
+
+    public AlarmNotFoundException() {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/team1/moim/domain/event/repository/AlarmRepository.java
+++ b/src/main/java/com/team1/moim/domain/event/repository/AlarmRepository.java
@@ -2,13 +2,12 @@ package com.team1.moim.domain.event.repository;
 
 import com.team1.moim.domain.event.entity.Alarm;
 import com.team1.moim.domain.event.entity.Event;
-import com.team1.moim.domain.event.entity.ToDoList;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     List<Alarm> findByEventAndSendYn(Event event, String sendYn);
+    List<Alarm> findByEventId(Long eventId);
 }

--- a/src/main/java/com/team1/moim/domain/event/service/EventService.java
+++ b/src/main/java/com/team1/moim/domain/event/service/EventService.java
@@ -5,8 +5,15 @@ import com.team1.moim.domain.event.dto.request.AlarmRequest;
 import com.team1.moim.domain.event.dto.request.EventRequest;
 import com.team1.moim.domain.event.dto.request.RepeatRequest;
 import com.team1.moim.domain.event.dto.request.ToDoListRequest;
+import com.team1.moim.domain.event.dto.response.AlarmResponse;
 import com.team1.moim.domain.event.dto.response.EventResponse;
-import com.team1.moim.domain.event.entity.*;
+import com.team1.moim.domain.event.entity.Alarm;
+import com.team1.moim.domain.event.entity.AlarmType;
+import com.team1.moim.domain.event.entity.Event;
+import com.team1.moim.domain.event.entity.Matrix;
+import com.team1.moim.domain.event.entity.Repeat;
+import com.team1.moim.domain.event.entity.RepeatType;
+import com.team1.moim.domain.event.entity.ToDoList;
 import com.team1.moim.domain.event.exception.EventNotFoundException;
 import com.team1.moim.domain.event.repository.AlarmRepository;
 import com.team1.moim.domain.event.repository.EventRepository;
@@ -20,14 +27,6 @@ import com.team1.moim.domain.notification.dto.EventNotification;
 import com.team1.moim.global.config.s3.S3Service;
 import com.team1.moim.global.config.sse.service.SseService;
 import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -36,6 +35,13 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -464,5 +470,16 @@ public class EventService {
     private Member findMemberByEmail() {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
         return memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+    }
+
+    // 단일 일정의 알람을 조회
+    public List<AlarmResponse> findAlarmByEventId(Long eventId) {
+//        Member member = findMemberByEmail();
+        List<AlarmResponse> alarmResponses = new ArrayList<>();
+        for (Alarm alarm : alarmRepository.findByEventId(eventId)) {
+            AlarmResponse alarmResponse = AlarmResponse.from(alarm);
+            alarmResponses.add(alarmResponse);
+        }
+        return alarmResponses;
     }
 }

--- a/src/main/java/com/team1/moim/domain/group/entity/Group.java
+++ b/src/main/java/com/team1/moim/domain/group/entity/Group.java
@@ -30,6 +30,7 @@ public class Group extends BaseTimeEntity {
     private String title;
 
     // 내용
+    @Column(length=1000)
     private String contents;
 
     // 활동시간

--- a/src/main/java/com/team1/moim/global/exception/ErrorCode.java
+++ b/src/main/java/com/team1/moim/global/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
 
     // Event
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 일정입니다."),
+    ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "설정한 알림이 없습니다."),
 
     // Notificaion
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 알림입니다.");


### PR DESCRIPTION
## #️⃣연관된 이슈
> * #86

## 📝작업한 내용

- 단일 일정의 알림을 조회하는 기능 추가
![image](https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/27791880/d71fa7c4-89d7-416c-8a6d-6a1c57e211f2)

- Event의 memo를 작성하는 도중에 255자 이상의 문자를 입력하면 `Data too long for column` 이라는 에러가 등장함.
- 참고자료: https://backendcode.tistory.com/183
- `@Column(length=1000)` 어노테이션을 필요한 컬럼에 붙여서 해결함
- 정상적으로 적용되기 위해서는 스키마 전체를 삭제 후 테스트해야 함.

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정
- [x] 기능 추가