### PR TITLE
반복 일정 수정(종류별 삭제, repeat_parent)

### DIFF
--- a/src/main/java/com/team1/moim/domain/event/entity/Event.java
+++ b/src/main/java/com/team1/moim/domain/event/entity/Event.java
@@ -155,4 +155,8 @@ public class Event extends BaseTimeEntity{
     public void matrixUpdate(Matrix newMatrix){
         this.matrix = newMatrix;
     }
+
+    public void setRepeatParent(long repeatParent) {
+        this.repeatParent = repeatParent;
+    }
 }

--- a/src/main/java/com/team1/moim/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/team1/moim/domain/event/repository/EventRepository.java
@@ -14,7 +14,7 @@ import java.util.List;
 public interface EventRepository extends JpaRepository<Event, Long> {
 
     List<Event> findByDeleteYnAndAlarmYn(String deleteYn, String alarmYn);
-    List<Event> findByRepeatParent(Long repeatParent);
+    List<Event> findByRepeatParentAndDeleteYn(Long repeatParent, String deleteYn);
     List<Event> findByMember(Member member);
 
     @Query("SELECT e FROM Event e WHERE e.member = :member AND (e.startDateTime <= :end AND e.endDateTime >= :start)")


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) * #90 

## 📝작업한 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 모든 반복일정에 repeat_parent삽입
<img width="1083" alt="Screenshot 2024-04-22 at 4 56 51 PM" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/125184448/55cc8356-3aa3-494f-894a-106af6feac1e">

- after- 이 이후 반복일정 삭제
<img width="1041" alt="Screenshot 2024-04-22 at 4 59 37 PM" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/125184448/7f0bc4cb-b53a-4f85-a2cb-b754259eb34f">



- 반복일정 중 마지막 일정 하나만 지웠을때 반복 종료날짜가 바로 직전 날짜로 바뀜
원래 반복일정 종료일
<img width="667" alt="Screenshot 2024-04-22 at 4 59 58 PM" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/125184448/41863c79-4c6a-4538-aafa-6d5efa7fe330">

마지막 반복일정인 23번을 지움
<img width="1074" alt="Screenshot 2024-04-22 at 5 01 44 PM" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/125184448/f1d4dce9-d5fb-417f-9771-5f738e2e15f8">

22번의 start-date에 맞춰서 repeat의 반복일정 종료일이 바뀜

<img width="651" alt="Screenshot 2024-04-22 at 5 04 26 PM" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/125184448/070100cc-8b73-4586-9669-ce42f04561ff">

<img width="1368" alt="Screenshot 2024-04-22 at 5 02 23 PM" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/125184448/a2c12041-78b5-4edc-83d4-c59a6ee15b6c">





## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 반복일정 삭제(after, only)버그 수정

