### PR TITLE
[Fix/Login] 만료된 Access Token 재발급 안되는 이슈 해결(#92)

### DIFF
--- a/src/main/java/com/team1/moim/global/config/security/jwt/JwtProvider.java
+++ b/src/main/java/com/team1/moim/global/config/security/jwt/JwtProvider.java
@@ -13,7 +13,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.HttpHeaders;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -51,7 +50,6 @@ public class JwtProvider {
 
     private final ObjectMapper objectMapper;
     private final MemberRepository memberRepository;
-
 
     /**
      * AccessToken 생성 메서드
@@ -99,6 +97,7 @@ public class JwtProvider {
 
         // 클라이언트에게 문자 형태로 응답을 하기 위함
         response.getWriter().write(result);
+
         log.info("재발급된 Access Token: {}", accessToken);
     }
 
@@ -204,15 +203,8 @@ public class JwtProvider {
      * 각 AccessToken, RefreshToken의 유효성을 검증할 때 사용한다.
      * 헤더의 토큰을 HS512 인증 방식을 통해 디코딩 후 유효성 확인
      */
-    public boolean isTokenValid(String token){
-        log.info("isTokenValid() 진입");
-        try {
-            JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
-            log.info("토큰이 유효합니다.");
-            return true;
-        } catch (Exception e){
-            log.error("유효하지 않은 토큰입니다. {}", e.getMessage());
-            return false;
-        }
+    public void validateToken(String token){
+        log.info("validateToken() 진입! 토큰 유효성 검증 시작!");
+        JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
     }
 }

--- a/src/main/java/com/team1/moim/global/config/security/jwt/exception/RefreshTokenNotFoundException.java
+++ b/src/main/java/com/team1/moim/global/config/security/jwt/exception/RefreshTokenNotFoundException.java
@@ -1,0 +1,14 @@
+package com.team1.moim.global.config.security.jwt.exception;
+
+import com.team1.moim.global.exception.ErrorCode;
+import com.team1.moim.global.exception.MoimException;
+import lombok.Getter;
+
+@Getter
+public class RefreshTokenNotFoundException extends MoimException {
+    private static final ErrorCode errorCode = ErrorCode.REFRESH_TOKEN_NOT_FOUND;
+
+    public RefreshTokenNotFoundException(){
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/team1/moim/global/exception/ErrorCode.java
+++ b/src/main/java/com/team1/moim/global/exception/ErrorCode.java
@@ -8,9 +8,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
-    JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "로그인이 만료 되었습니다."),
+    JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "인증 토큰이 만료 되었습니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     LOGIN_FAILED(HttpStatus.BAD_REQUEST, "로그인에 실패했습니다. 이메일 또는 비밀번호를 확인해주세요."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "DB에 해당 Refresh Token이 존재하지 않습니다."),
 
     // Auth
     NOT_FOUND_CODE(HttpStatus.BAD_REQUEST, "발송한 인증코드가 없습니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈
* #92 

## 📝작업한 내용
* 프론트로부터 받아온 Access Token이 만료되었으면, 응답 헤더에 401 상태값 반환
* 프론트로부터 받은 요청 헤더에 Refresh Token이 있으면, DB의 Refresh Token 존재 여부 및 유효성 검증 후 Access Token 재발급
* Refresh Token 예외 및 에러 코드 추가

## 결과

### 토큰 만료 전 일정 생성
1. DB
<img width="807" alt="토큰_만료전_일정생성_db" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/60949121/8914e17d-2d75-4273-aa02-7bc9fc9cf6a9">

2. 프론트 콘솔
<img width="1089" alt="토큰_만료전_일정생성_vue_log" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/60949121/078248fb-bd14-4c0c-8dc2-ec03be2050f3">

### 토큰 만료 후 일정 생성
1. DB
<img width="1006" alt="토큰_만료후_일정생성_db" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/60949121/dbaf3316-fe93-4dbe-ae76-df88d0c628f4">

2. 프론트 콘솔
<img width="1406" alt="토큰_만료후_일정생성_vue_log" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/60949121/d0ec097e-e8b4-4537-b524-c431a6e4250e">

3. 서버에서 재발급한 Access Token을 프론트 Local Storage Access Token에 업데이트
<img width="1218" alt="토큰_만료후_일정생성_재발급AT와_동일_spring_log" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/60949121/40b45cdb-4afe-4617-bd8f-44f6e2c955f3">
<img width="1241" alt="토큰_만료후_일정생성_localStorage_AT_update" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/60949121/d4a47dfb-6f51-4a74-8393-09aa6c8ec741">

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정
- [x] 기능 추가
- [x] 코드 스타일 변경 (formatting, local variables)
- [x] 리팩토링 (기능 변경 X)