### PR TITLE
모임 리스트 조회기능 추가

### DIFF
--- a/src/main/java/com/team1/moim/domain/group/controller/GroupController.java
+++ b/src/main/java/com/team1/moim/domain/group/controller/GroupController.java
@@ -105,15 +105,14 @@ public class GroupController {
     @GetMapping("/groups")
     public ResponseEntity<ApiSuccessResponse<List<ListGroupResponse>>> findAllGroups(
             HttpServletRequest httpServletRequest,
-            GroupSearchRequest groupSearchRequest,
             Pageable pageable) {
-        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiSuccessResponse.of(
                         HttpStatus.OK,
                         httpServletRequest.getServletPath(),
-                        groupService.findGroups(groupSearchRequest, pageable, email)));
+                        groupService.findGroups(pageable)));
     }
 
     @PostMapping("/{groupId}/groupInfo/{groupInfoId}/notification")

--- a/src/main/java/com/team1/moim/domain/group/dto/response/ListGroupResponse.java
+++ b/src/main/java/com/team1/moim/domain/group/dto/response/ListGroupResponse.java
@@ -1,8 +1,11 @@
 package com.team1.moim.domain.group.dto.response;
 
 import com.team1.moim.domain.group.entity.Group;
+import com.team1.moim.domain.group.entity.GroupInfo;
 import com.team1.moim.domain.member.entity.Member;
 import java.time.LocalDateTime;
+import java.util.List;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,7 +13,6 @@ import lombok.Getter;
 @Builder
 public class ListGroupResponse {
     private Long id;
-    private Member member;
     private String title;
     private int runningTime;
     private LocalDateTime voteDeadline;
@@ -18,11 +20,14 @@ public class ListGroupResponse {
     private int participants;
     private String isConfirmed;
     private String isDeleted;
+    private String hostEmail;
+    private String hostNickname;
+    private List<String[]> guestEmailNicknameIsAgreed;
 
-    public static ListGroupResponse from(Group group) {
+
+    public static ListGroupResponse from(Group group, List<String[]> guestEmailNicknameIsAgreed) {
         return ListGroupResponse.builder()
                 .id(group.getId())
-                .member(group.getMember())
                 .title(group.getTitle())
                 .runningTime(group.getRunningTime())
                 .voteDeadline(group.getVoteDeadline())
@@ -30,6 +35,9 @@ public class ListGroupResponse {
                 .participants(group.getParticipants())
                 .isConfirmed(group.getIsConfirmed())
                 .isDeleted(group.getIsDeleted())
+                .hostEmail(group.getMember().getEmail())
+                .hostNickname(group.getMember().getNickname())
+                .guestEmailNicknameIsAgreed(guestEmailNicknameIsAgreed)
                 .build();
     }
 }

--- a/src/main/java/com/team1/moim/domain/group/repository/GroupInfoRepository.java
+++ b/src/main/java/com/team1/moim/domain/group/repository/GroupInfoRepository.java
@@ -11,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface GroupInfoRepository extends JpaRepository<GroupInfo, Long> {
     List<GroupInfo> findByGroup(Group group);
     List<GroupInfo> findByGroupAndIsAgreed(Group group, String isAgreed);
+
+    List<GroupInfo> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/team1/moim/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/team1/moim/domain/group/repository/GroupRepository.java
@@ -23,4 +23,8 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
 
     List<Group> findByIsDeleted(String isDeleted);
     List<Group> findByIsConfirmedAndIsDeleted(String isConfirmed, String isDeleted);
+
+    List<Group> findByMemberId(Long memberId);
+
+
 }

--- a/src/main/java/com/team1/moim/domain/group/service/GroupService.java
+++ b/src/main/java/com/team1/moim/domain/group/service/GroupService.java
@@ -205,48 +205,81 @@ public class GroupService {
 
     // 전체 모임 조회하기
     @Transactional
-    public List<ListGroupResponse> findGroups(
-            GroupSearchRequest groupSearchRequest, Pageable pageable, String loginEmail) {
+    public List<ListGroupResponse> findGroups(Pageable pageable) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
 
-        Specification<Group> spec = new Specification<>() {
-            @Override
-            public Predicate toPredicate(Root<Group> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) {
-                List<Predicate> predicates = new ArrayList<>();
+        List<GroupInfo> guestGroupInfo = groupInfoRepository.findByMemberId(member.getId()); // 자기가 게스트인 그룹의 인포
+        List<Group> groups = groupRepository.findByMemberId(member.getId()); // 자기가 호스트인 그룹
 
-                // Group 테이블과 GroupInfo 테이블을 조인하고, 그 결과에서 특정 멤버의 이메일이 loginEmail과 같은 그룹만 선택
-                // SELECT * FROM Group g
-                // JOIN GroupInfo gi ON g.id = gi.group_id
-                // WHERE gi.member.email = :loginEmail
-                Join<Group, GroupInfo> groupJoin = root.join("groupInfos");
-                predicates.add(criteriaBuilder.equal(groupJoin.get("member").get("email"), loginEmail));
+        for (GroupInfo groupInfo : guestGroupInfo){
+            groups.add(groupInfo.getGroup());
+        }
+        // 자기가 속한 모든 그룹 = groups
 
-                // 삭제되지 않은 그룹
-                predicates.add(criteriaBuilder.equal(root.get("isDeleted"), "N"));
+        List<ListGroupResponse> groupResponse = new ArrayList<>();
 
-                // filterConfirmed가 true일 경우, 명시적으로 "확정"(isConfirmed가 "Y")된 그룹을 검색
-                // filterWaiting가 true일 경우, "대기" 상태(isConfirmed가 "N"이고 isAgreed가 "N")인 그룹을 검색
-                // filterAdjusting가 true일 경우, "조율" 상태(isConfirmed가 "N"이고 isAgreed가 "Y")인 그룹을 검색
-                // 사용자가 특정 상태의 그룹만 보고 싶다면, 해당 상태에 대한 필터를 true로 설정.
-                // 모든 그룹을 확인하고 싶다면, 모든 필터를 false로 두거나 설정하지 않으면 됨.
 
-                if (groupSearchRequest.isFilterConfirmed()) {
-                    predicates.add(criteriaBuilder.equal(groupJoin.get("isConfirmed"), "Y"));
-                } else if (groupSearchRequest.isFilterWaiting()) {
-                    predicates.add(criteriaBuilder.equal(groupJoin.get("isConfirmed"), "N"));
-                    predicates.add(criteriaBuilder.equal(groupJoin.get("isAgreed"), "N"));
-                } else if (groupSearchRequest.isFilterAdjusting()) {
-                    predicates.add(criteriaBuilder.equal(groupJoin.get("isConfirmed"), "N"));
-                    predicates.add(criteriaBuilder.equal(groupJoin.get("isAgreed"), "Y"));
-                }
 
-                return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+        for(Group group: groups){ // 자기가 속한 모든 그룹의 정보를 추출
+            List<String[]> guestEmailNicknameIsAgreed = new ArrayList<>(); // 각 그룹의 게스트 이메일, 닉네임, 동의여부
+            List<GroupInfo> tempGroupInfos = groupInfoRepository.findByGroup(group);
+
+            for(GroupInfo groupInfo : tempGroupInfos){
+                guestEmailNicknameIsAgreed.add(new String[]{groupInfo.getMember().getEmail(),
+                                                            groupInfo.getMember().getNickname(),
+                                                            groupInfo.getIsAgreed()});
+
             }
-        };
+            groupResponse.add(ListGroupResponse.from(group, guestEmailNicknameIsAgreed));
+        }
 
-        List<ListGroupResponse> groups = groupRepository.findAll(spec, pageable).stream()
-                .map(ListGroupResponse::from)
-                .collect(Collectors.toList());
-        return groups;
+
+//        for(Group group1: groups){
+//            groupResponse.add(ListGroupResponse.from(group1, guestEmailNicknameIsAgreed));
+//        }
+
+
+
+//        Specification<Group> spec = new Specification<>() {
+//            @Override
+//            public Predicate toPredicate(Root<Group> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) {
+//                List<Predicate> predicates = new ArrayList<>();
+//
+//                // Group 테이블과 GroupInfo 테이블을 조인하고, 그 결과에서 특정 멤버의 이메일이 loginEmail과 같은 그룹만 선택
+//                // SELECT * FROM Group g
+//                // JOIN GroupInfo gi ON g.id = gi.group_id
+//                // WHERE gi.member.email = :loginEmail
+//                Join<Group, GroupInfo> groupJoin = root.join("groupInfos");
+//                predicates.add(criteriaBuilder.equal(groupJoin.get("member").get("email"), loginEmail));
+//
+//                // 삭제되지 않은 그룹
+//                predicates.add(criteriaBuilder.equal(root.get("isDeleted"), "N"));
+//
+//                // filterConfirmed가 true일 경우, 명시적으로 "확정"(isConfirmed가 "Y")된 그룹을 검색
+//                // filterWaiting가 true일 경우, "대기" 상태(isConfirmed가 "N"이고 isAgreed가 "N")인 그룹을 검색
+//                // filterAdjusting가 true일 경우, "조율" 상태(isConfirmed가 "N"이고 isAgreed가 "Y")인 그룹을 검색
+//                // 사용자가 특정 상태의 그룹만 보고 싶다면, 해당 상태에 대한 필터를 true로 설정.
+//                // 모든 그룹을 확인하고 싶다면, 모든 필터를 false로 두거나 설정하지 않으면 됨.
+//
+//                if (groupSearchRequest.isFilterConfirmed()) {
+//                    predicates.add(criteriaBuilder.equal(groupJoin.get("isConfirmed"), "Y"));
+//                } else if (groupSearchRequest.isFilterWaiting()) {
+//                    predicates.add(criteriaBuilder.equal(groupJoin.get("isConfirmed"), "N"));
+//                    predicates.add(criteriaBuilder.equal(groupJoin.get("isAgreed"), "N"));
+//                } else if (groupSearchRequest.isFilterAdjusting()) {
+//                    predicates.add(criteriaBuilder.equal(groupJoin.get("isConfirmed"), "N"));
+//                    predicates.add(criteriaBuilder.equal(groupJoin.get("isAgreed"), "Y"));
+//                }
+//
+//                return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+//            }
+//        };
+
+//        List<ListGroupResponse> groups = groupRepository.findAll( pageable).stream()
+//                .map(ListGroupResponse::from)
+//                .collect(Collectors.toList());
+        return groupResponse;
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) * #95 

## 📝작업한 내용
> 자신이 속한 모임(호스트, 게스트)의 모든 그룹 정보와, 게스트들의 이메일, 닉네임, 동의 여부가 나옴
<img width="630" alt="Screenshot 2024-04-24 at 10 44 32 AM" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/125184448/10cccd47-80bb-41ea-ad34-c996bbe13dc3">
"guestEmailNicknameIsAgreed": [
                [
                    "user@user.com",
                    "user",
                    "P"
                ],
                [
                    "baker@user.com",
                    "baker",
                    "P"
                ],
                [
                    "abbie@user.com",
                    "abbie",
                    "P"
                ]
            ]
            이런 식으로 게스트의 이메일, 닉네임, 동의여부가 묶여서 배열로 나옴

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 기능 추가

