### PR TITLE
[Fix] 아이젠하워 매트릭스 조회 관련 수정

### DIFF
--- a/src/main/java/com/team1/moim/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/team1/moim/domain/event/repository/EventRepository.java
@@ -16,6 +16,7 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findByDeleteYnAndAlarmYn(String deleteYn, String alarmYn);
     List<Event> findByRepeatParentAndDeleteYn(Long repeatParent, String deleteYn);
     List<Event> findByMember(Member member);
+    List<Event> findByMemberAndDeleteYn(Member member, String deleteYn);
 
     @Query("SELECT e FROM Event e WHERE e.member = :member AND e.deleteYn = 'N' AND (e.startDateTime <= :end AND e.endDateTime >= :start)")
     List<Event> findByMemberAndDateRange(@Param("member") Member member, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
@@ -26,7 +27,7 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     @Query("SELECT e FROM Event e WHERE e.member = :member AND FUNCTION('YEAR', e.startDateTime) = :year AND FUNCTION('MONTH', e.startDateTime) = :month AND FUNCTION('DAY', e.startDateTime) = :day")
     List<Event> findByMemberAndYearAndMonthAndDay(@Param("member") Member member, @Param("year") int year, @Param("month") int month, @Param("day") int day);
 
-    @Query("SELECT e FROM Event e WHERE e.member = :member AND (e.title LIKE %:content% OR e.memo LIKE %:content%)")
+    @Query("SELECT e FROM Event e WHERE e.member = :member AND e.deleteYn = 'N' AND (e.title LIKE %:content% OR e.memo LIKE %:content%)")
     List<Event> findByMemberAndTitleOrMemo(@Param("member") Member member, @Param("content") String content);
 
 

--- a/src/main/java/com/team1/moim/domain/event/service/EventService.java
+++ b/src/main/java/com/team1/moim/domain/event/service/EventService.java
@@ -326,7 +326,7 @@ public class EventService {
 
     public List<EventResponse> matrixEvents(Matrix matrix) {
         Member member = findMemberByEmail();
-        List<Event> events = eventRepository.findByMember(member);
+        List<Event> events = eventRepository.findByMemberAndDeleteYn(member, "N");
 
         return events.stream()
                 .filter(event -> event.getMatrix().equals(matrix))


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) * #이슈번호

## 📝작업한 내용

- 아이젠하워 매트릭스에서 삭제된 일정도 조회하는 문제를 해결
- EventRepository에 `List<Event> findByMemberAndDeleteYn(Member member, String deleteYn);` 를 새롭게 생성해서 활용

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정