### PR TITLE
[Fix] 국경일 정보 조회하지 못하는 문제 수정

### DIFF
--- a/src/main/java/com/team1/moim/domain/event/controller/EventController.java
+++ b/src/main/java/com/team1/moim/domain/event/controller/EventController.java
@@ -148,7 +148,7 @@ public class EventController {
         ArrayList<HashMap<String, Object>> responseHolidayArr = new ArrayList<>();
 
         try {
-            Map<String, Object> holidayMap = PublicHoliyDayAPI.holidayInfoAPI(year, month);
+            Map<String, Object> holidayMap = publicHoliyDayAPI.holidayInfoAPI(year, month);
             Map<String, Object> response = (Map<String, Object>) holidayMap.get("response");
             Map<String, Object> body = (Map<String, Object>) response.get("body");
 

--- a/src/main/java/com/team1/moim/domain/event/service/PublicHoliyDayAPI.java
+++ b/src/main/java/com/team1/moim/domain/event/service/PublicHoliyDayAPI.java
@@ -32,8 +32,6 @@ public class PublicHoliyDayAPI {
         urlBuilder.append("&" + URLEncoder.encode("_type", "UTF-8") + "=" + URLEncoder.encode("json", "UTF-8")); /* json으로 요청 */
 
         URL url = new URL(urlBuilder.toString());
-        log.info("url: " + url);
-
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.setRequestMethod("GET");
         conn.setRequestProperty("Content-type", "application/json");

--- a/src/main/java/com/team1/moim/domain/event/service/PublicHoliyDayAPI.java
+++ b/src/main/java/com/team1/moim/domain/event/service/PublicHoliyDayAPI.java
@@ -19,9 +19,10 @@ import java.util.Map;
 @Slf4j
 public class PublicHoliyDayAPI {
     @Value("${custom.api.secretKey}")
-    private static String secretKey;
+    private String secretKey;
 
-    public static Map<String, Object> holidayInfoAPI(String year, String month) throws IOException {
+    public Map<String, Object> holidayInfoAPI(String year, String month) throws IOException {
+        System.out.println(secretKey);
         StringBuilder urlBuilder = new StringBuilder("http://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService/getHoliDeInfo"); /*URL*/
         urlBuilder.append("?" + URLEncoder.encode("serviceKey", "UTF-8") + "=" + secretKey); /*Service Key*/
         urlBuilder.append("&" + URLEncoder.encode("pageNo", "UTF-8") + "=" + URLEncoder.encode("1", "UTF-8")); /*페이지번호*/
@@ -31,6 +32,7 @@ public class PublicHoliyDayAPI {
         urlBuilder.append("&" + URLEncoder.encode("_type", "UTF-8") + "=" + URLEncoder.encode("json", "UTF-8")); /* json으로 요청 */
 
         URL url = new URL(urlBuilder.toString());
+        log.info("url: " + url);
 
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.setRequestMethod("GET");
@@ -49,7 +51,7 @@ public class PublicHoliyDayAPI {
         }
         rd.close();
         conn.disconnect();
-        log.info(sb.toString());
+        log.info("!!! " + sb.toString());
 
         return stringToMap(sb.toString());
     }

--- a/src/main/java/com/team1/moim/global/config/security/jwt/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/team1/moim/global/config/security/jwt/JwtAuthenticationProcessingFilter.java
@@ -13,6 +13,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -22,25 +23,20 @@ import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.ErrorResponse;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
-
 /**
- * 클라이언트가 헤더에 JWT 토큰을 담아서 "/login" URL 이외의 요청을 보내면,
- * 해당 토큰들의 유효성을 검사하여 인증 처리/인증 실패/토큰 재발급 등을 수행
- * 1. 요청 헤더에 RT가 없고, AT가 유효한 경우 -> 인증 성공 처리, RT 재발급 X
- * 2. 요청 헤더에 RT가 없고, AT가 없거나 유효하지 않은 경우 -> 인증 실패 처리(403)
- * 3. 요청 헤더에 RT가 있는 경우 -> DB에 있는 RT와의 일치여부가 검증되면 AT, RT 재발급 (RTR 방식)
+ * 클라이언트가 헤더에 JWT 토큰을 담아서 "/login" URL 이외의 요청을 보내면, 해당 토큰들의 유효성을 검사하여 인증 처리/인증 실패/토큰 재발급 등을 수행 1. 요청 헤더에 RT가 없고, AT가 유효한
+ * 경우 -> 인증 성공 처리, RT 재발급 X 2. 요청 헤더에 RT가 없고, AT가 없거나 유효하지 않은 경우 -> 인증 실패 처리(403) 3. 요청 헤더에 RT가 있는 경우 -> DB에 있는 RT와의
+ * 일치여부가 검증되면 AT, RT 재발급 (RTR 방식)
  */
 @RequiredArgsConstructor
 @Slf4j
 public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
     // 아래 url로 들어오는 요청은 Filter 작동 X
-    private static final String[] NO_CHECK_URLS =
-            {"/login",
+    private static final String[] NO_CHECK_URLS = {
+            "/login",
             "/oauth2/authorization/google",
             "/login/oauth2/code/google",
             "/favicon.ico",
@@ -48,7 +44,9 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
             "/api/auth/send",
             "/api/auth/verify",
             "/api/auth/email-validate",
-            "/api/auth/nickname-validate"};
+            "/api/auth/nickname-validate",
+            "/api/events/getHoliday"
+    };
 
     private final JwtProvider jwtProvider;
     private final MemberRepository memberRepository;
@@ -64,8 +62,8 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException, JwtExpiredException {
         log.info("JWT Filter 진입");
         log.info("requestURI: " + request.getRequestURI());
-        for (String url : NO_CHECK_URLS){
-            if (request.getRequestURI().equals(url)){
+        for (String url : NO_CHECK_URLS) {
+            if (request.getRequestURI().equals(url)) {
                 log.info(url + " 필터 통과");
                 filterChain.doFilter(request, response); // NO_CHECK_URLS로 요청 들어오면 다음 필터 호출
                 return; // 이후 현재 필터 진행 막기 (안해주면 아래로 내려가서 계속 필터 진행 시킴)
@@ -78,7 +76,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
             // 요청 헤더에 RT가 있는 경우는, AT가 만료되어 요청한 경우 밖에 없음
             // 요청 헤더의 RT가 유효하고, DB에 있는 RT와 일치하면 AT 재발급
             String refreshTokenFromHeader = jwtProvider.extractRefreshToken(request).orElse(null);
-            if (refreshTokenFromHeader != null){
+            if (refreshTokenFromHeader != null) {
                 log.info("Refresh Token 검증을 시작합니다.");
                 Member findMember = memberRepository.findByRefreshToken(refreshTokenFromHeader)
                         .orElseThrow(RefreshTokenNotFoundException::new);
@@ -93,7 +91,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
             }
 
             checkAccessTokenAndAuthentication(request, response, filterChain);
-        } catch (TokenExpiredException e){
+        } catch (TokenExpiredException e) {
             log.error("유효기간이 만료된 토큰입니다. : {}", e.getMessage());
             HttpServletResponse httpServletResponse = (HttpServletResponse) response;
             httpServletResponse.setStatus(ErrorCode.JWT_EXPIRED.getStatus().value());
@@ -103,8 +101,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     }
 
     /**
-     * 요청 헤더에서 추출한 RT로 유저 정보를 찾고,
-     * 유저가 있으면 AT 재발급해서 응답 헤더에 보냄
+     * 요청 헤더에서 추출한 RT로 유저 정보를 찾고, 유저가 있으면 AT 재발급해서 응답 헤더에 보냄
      */
     public void reissueAccessToken(HttpServletResponse response, Member member) throws IOException {
         log.info("Access Token 재발급 시작!");
@@ -133,16 +130,13 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     }
 
     /**
-     * 인증 허가 메서드
-     * 파라미터의 member: 우리가 만든 회원 객체 / Builder의 유저: UserDetails의 User 객체
-     * 소셜 로그인을 한 유저의 경우, 비밀번호 값을 받아오지 못하기 때문에,
-     * passwordUtil을 이용해 자체 랜덤 비밀번호 생성
-     * SecurityContextHolder.getContext()로 SecurityContext를 꺼낸 후,
-     * setAuthentication()을 이용하여 위에서 만든 Authentication 객체에 대한 인증 허가 처리
+     * 인증 허가 메서드 파라미터의 member: 우리가 만든 회원 객체 / Builder의 유저: UserDetails의 User 객체 소셜 로그인을 한 유저의 경우, 비밀번호 값을 받아오지 못하기 때문에,
+     * passwordUtil을 이용해 자체 랜덤 비밀번호 생성 SecurityContextHolder.getContext()로 SecurityContext를 꺼낸 후, setAuthentication()을
+     * 이용하여 위에서 만든 Authentication 객체에 대한 인증 허가 처리
      */
-    public void saveAuthentication(Member currentMember){
+    public void saveAuthentication(Member currentMember) {
         String password = currentMember.getPassword();
-        if (password == null){ // 소셜 로그인 유저의 비밀번호 임의로 설정 하여 소셜 로그인 유저도 인증 되도록 설정
+        if (password == null) { // 소셜 로그인 유저의 비밀번호 임의로 설정 하여 소셜 로그인 유저도 인증 되도록 설정
             password = PasswordUtil.generateRandomPassword();
         }
 
@@ -154,7 +148,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
         // UsernamePasswordAuthenticationToken으로, Authentication 객체 생성
         // 두번째 파라미터(credential)는 보통 비밀번호로, 인증 시에는 보통 null로 제거
-        Authentication authentication = 
+        Authentication authentication =
                 new UsernamePasswordAuthenticationToken(userDetails, null,
                         authoritiesMapper.mapAuthorities(userDetails.getAuthorities()));
 
@@ -163,11 +157,9 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     }
 
     /**
-     * RT를 재발급 해주는 메서드
-     * RT 만료 시에는 에러 메시지를 발송하여 클라이언트를 로그아웃 처리하므로, 사용 안함.
-     * 즉, RT 재발급 자체를 안함.
+     * RT를 재발급 해주는 메서드 RT 만료 시에는 에러 메시지를 발송하여 클라이언트를 로그아웃 처리하므로, 사용 안함. 즉, RT 재발급 자체를 안함.
      */
-    private String reIssueRefreshToken(Member member){
+    private String reIssueRefreshToken(Member member) {
         String reIssuedRefreshToken = jwtProvider.createRefreshToken();
         member.updateRefreshToken(reIssuedRefreshToken);
         memberRepository.saveAndFlush(member);


### PR DESCRIPTION
## 📝작업한 내용

- 국경일 정보를 불러오지 못하는 문제를 해결

### AS-IS

- secretKey가 static으로 선언되어 있었고, 그렇다보니 국경일 정보 조회를 위한 URL 조립 시 secretKey를 불러오지 못하고 null로 찍히는 문제가 있었음.

```java
private static String secretKey;
```

### TO-BE

- secretKey와 secretKey를 사용하는 PublicHolidayAPI의 holidayInfoAPI도 static을 제거함
- EventController에서도 이미 생성자 주입을 받은 PublicHoliyDayAPI를 사용하도록 수정함

```java
private String secretKey;
public Map<String, Object> holidayInfoAPI(String year, String month) throws IOException {
   ...
}
```

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정