### PR TITLE
[Feat/oauth] 구글, 카카오 로그인 백엔드에 연결

### DIFF
--- a/src/main/java/com/team1/moim/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/team1/moim/domain/auth/dto/request/SignUpRequest.java
@@ -1,5 +1,6 @@
 package com.team1.moim.domain.auth.dto.request;
 
+import com.team1.moim.domain.member.entity.LoginType;
 import com.team1.moim.domain.member.entity.Member;
 import com.team1.moim.domain.member.entity.Role;
 import jakarta.validation.constraints.Email;
@@ -24,6 +25,7 @@ public class SignUpRequest {
 
     public Member toEntity(PasswordEncoder passwordEncoder, Role role, String imageUrl){
         String finalPassword = null;
+
         if (password != null){
             finalPassword = passwordEncoder.encode(password);
         }
@@ -33,9 +35,8 @@ public class SignUpRequest {
                 .password(finalPassword)
                 .nickname(nickname)
                 .profileImage(imageUrl)
+                .loginType(LoginType.NORMAL)
                 .role(role)
-                .socialType(null)
-                .socialId(null)
                 .build();
     }
 }

--- a/src/main/java/com/team1/moim/domain/member/controller/MemberController.java
+++ b/src/main/java/com/team1/moim/domain/member/controller/MemberController.java
@@ -1,6 +1,5 @@
 package com.team1.moim.domain.member.controller;
 
-import com.team1.moim.domain.auth.dto.request.SignUpRequest;
 import com.team1.moim.domain.member.dto.request.UpdateRequest;
 import com.team1.moim.domain.member.dto.response.MemberResponse;
 import com.team1.moim.domain.member.service.MemberService;

--- a/src/main/java/com/team1/moim/domain/member/entity/Account.java
+++ b/src/main/java/com/team1/moim/domain/member/entity/Account.java
@@ -1,0 +1,45 @@
+package com.team1.moim.domain.member.entity;
+
+import com.team1.moim.global.config.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Account extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String profileImage;
+
+    private String socialId; // 로그인 한 소셜 타입의 식별자 값 (일반 로그인은 null)
+
+    @Enumerated(EnumType.STRING)
+    private LoginType loginType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Builder
+    public Account(String email, String profileImage, String socialId, LoginType loginType){
+        this.email = email;
+        this.profileImage = profileImage;
+        this.socialId = socialId;
+        this.loginType = loginType;
+    }
+
+    public void attachMember(Member member) {
+        this.member = member;
+        member.getAccounts().add(this);
+    }
+}

--- a/src/main/java/com/team1/moim/domain/member/entity/LoginType.java
+++ b/src/main/java/com/team1/moim/domain/member/entity/LoginType.java
@@ -1,0 +1,5 @@
+package com.team1.moim.domain.member.entity;
+
+public enum LoginType {
+    NORMAL, KAKAO, GOOGLE
+}

--- a/src/main/java/com/team1/moim/domain/member/entity/Member.java
+++ b/src/main/java/com/team1/moim/domain/member/entity/Member.java
@@ -20,7 +20,7 @@ public class Member extends BaseTimeEntity {
     private Long id;
 
     @Column(unique = true, nullable = false)
-    private String email;
+    private String email; // 대표 이메일
 
     // 소셜 로그인 유저의 경우 비밀번호가 필요 없으므로, nullable
     private String password;
@@ -29,7 +29,10 @@ public class Member extends BaseTimeEntity {
     private String nickname;
 
     @Column(nullable = false)
-    private String profileImage;
+    private String profileImage; // 대표 프로필 이미지
+
+    @Enumerated(EnumType.STRING)
+    private LoginType loginType; // 대표 로그인 타입
 
     private String refreshToken;
 
@@ -37,35 +40,41 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    @Enumerated(EnumType.STRING)
-    private SocialType socialType = null;
-
-    private String socialId = null; // 로그인 한 소셜 타입의 식별자 값 (일반 로그인은 null)
-
     @Column(nullable = false)
     private String deleteYn = "N";
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Account> accounts = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Event> events = new ArrayList<>();
 
     @Builder
-    public Member(String email, String password, String nickname,
-                  String profileImage, Role role, SocialType socialType, String socialId) {
+    public Member(String email, String password, String nickname, String profileImage, LoginType loginType, Role role) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.profileImage = profileImage;
+        this.loginType = loginType;
         this.role = role;
-        this.socialType = socialType;
-        this.socialId = socialId;
     }
 
     public void withdraw() {
         this.deleteYn = "Y";
     }
 
+    public void authorizeUser(){
+        this.role = Role.USER;
+    }
+
     public void updateRefreshToken(String refreshToken){
         this.refreshToken = refreshToken;
+    }
+
+    public void updateRepresentativeData(String email, String profileImage, LoginType loginType){
+        this.email = email;
+        this.profileImage = profileImage;
+        this.loginType = loginType;
     }
 
     public void updateMember(String nickname, String profileImage){

--- a/src/main/java/com/team1/moim/domain/member/entity/Role.java
+++ b/src/main/java/com/team1/moim/domain/member/entity/Role.java
@@ -5,5 +5,5 @@ import lombok.Getter;
 @Getter
 public enum Role {
     // 스프링 시큐리티에서는 권한(Role) 코드에 항상 "ROLE_" 접두사가 앞에 붙어야 함
-    USER, ADMIN
+    USER, ADMIN, GUEST
 }

--- a/src/main/java/com/team1/moim/domain/member/entity/SocialType.java
+++ b/src/main/java/com/team1/moim/domain/member/entity/SocialType.java
@@ -1,5 +1,0 @@
-package com.team1.moim.domain.member.entity;
-
-public enum SocialType {
-    KAKAO, GOOGLE
-}

--- a/src/main/java/com/team1/moim/domain/member/exception/AccountNotFoundException.java
+++ b/src/main/java/com/team1/moim/domain/member/exception/AccountNotFoundException.java
@@ -1,0 +1,15 @@
+package com.team1.moim.domain.member.exception;
+
+import com.team1.moim.global.exception.ErrorCode;
+import com.team1.moim.global.exception.MoimException;
+import lombok.Getter;
+
+@Getter
+public class AccountNotFoundException extends MoimException {
+
+    private static final ErrorCode errorCode = ErrorCode.ACCOUNT_NOT_FOUND;
+
+    public AccountNotFoundException(){
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/team1/moim/domain/member/repository/AccountRepository.java
+++ b/src/main/java/com/team1/moim/domain/member/repository/AccountRepository.java
@@ -1,0 +1,14 @@
+package com.team1.moim.domain.member.repository;
+
+import com.team1.moim.domain.member.entity.Account;
+import com.team1.moim.domain.member.entity.LoginType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AccountRepository extends JpaRepository<Account, Long> {
+    Optional<Account> findByLoginTypeAndSocialId(LoginType loginType, String socialId);
+    Optional<Account> findByEmail(String email);
+}

--- a/src/main/java/com/team1/moim/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/team1/moim/domain/member/repository/MemberRepository.java
@@ -1,8 +1,6 @@
 package com.team1.moim.domain.member.repository;
 
-import com.team1.moim.domain.event.entity.Event;
 import com.team1.moim.domain.member.entity.Member;
-import com.team1.moim.domain.member.entity.SocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,7 +14,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByNickname(String nickname);
     Optional<Member> findByEmail(String email);
     Optional<Member> findByRefreshToken(String refreshToken);
-    Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
 
     @Query("SELECT m FROM Member m WHERE m <> :member AND m.deleteYn = 'N'")
     List<Member> findAllMemberExcept(@Param("member") Member member);

--- a/src/main/java/com/team1/moim/domain/member/service/MemberService.java
+++ b/src/main/java/com/team1/moim/domain/member/service/MemberService.java
@@ -13,7 +13,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,7 +23,6 @@ public class MemberService {
 
     private static final String FILE_TYPE = "members";
     private final S3Service s3Service;
-
     private final MemberRepository memberRepository;
 
     @Transactional
@@ -32,7 +30,7 @@ public class MemberService {
         Member findMember = findMember();
         findMember.withdraw();
 
-        return findMember.getEmail() + " 회원을 삭제하였습니다.";
+        return findMember.getNickname() + " 회원을 삭제하였습니다.";
     }
 
     @Transactional

--- a/src/main/java/com/team1/moim/global/config/security/PasswordUtil.java
+++ b/src/main/java/com/team1/moim/global/config/security/PasswordUtil.java
@@ -1,4 +1,4 @@
-package com.team1.moim.global.config.security.oauth2.util;
+package com.team1.moim.global.config.security;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/com/team1/moim/global/config/security/jwt/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/team1/moim/global/config/security/jwt/JwtAuthenticationProcessingFilter.java
@@ -6,7 +6,7 @@ import com.team1.moim.domain.member.exception.MemberNotFoundException;
 import com.team1.moim.domain.member.repository.MemberRepository;
 import com.team1.moim.global.config.security.jwt.exception.JwtExpiredException;
 import com.team1.moim.global.config.security.jwt.exception.RefreshTokenNotFoundException;
-import com.team1.moim.global.config.security.oauth2.util.PasswordUtil;
+import com.team1.moim.global.config.security.PasswordUtil;
 import com.team1.moim.global.exception.ErrorCode;
 import com.team1.moim.global.exception.ErrorDetail;
 import jakarta.servlet.FilterChain;
@@ -36,10 +36,14 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
     // 아래 url로 들어오는 요청은 Filter 작동 X
     private static final String[] NO_CHECK_URLS = {
+            "/",
             "/login",
+            "/oauth2/authorize/google",
+            "/oauth2/authorize/kakao",
             "/oauth2/authorization/google",
+            "/oauth2/authorization/kakao",
             "/login/oauth2/code/google",
-            "/favicon.ico",
+            "/login/oauth2/code/kakao",
             "/api/auth/sign-up",
             "/api/auth/send",
             "/api/auth/verify",
@@ -105,7 +109,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
      */
     public void reissueAccessToken(HttpServletResponse response, Member member) throws IOException {
         log.info("Access Token 재발급 시작!");
-        String reissuedAccessToken = jwtProvider.createAccessToken(member.getEmail(), member.getRole().name());
+        String reissuedAccessToken = jwtProvider.createAccessToken(member.getNickname(), member.getRole().name());
         jwtProvider.sendAccessToken(response, reissuedAccessToken);
     }
 
@@ -120,8 +124,8 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
         String accessTokenFromHeader = jwtProvider.extractAccessToken(request).orElse(null);
         jwtProvider.validateToken(accessTokenFromHeader);
-        String email = jwtProvider.extractEmail(accessTokenFromHeader).orElse(null);
-        Member findMember = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+        String nickname = jwtProvider.extractNickname(accessTokenFromHeader).orElse(null);
+        Member findMember = memberRepository.findByNickname(nickname).orElseThrow(MemberNotFoundException::new);
         saveAuthentication(findMember);
 
         log.info("Authentication 객체에 대한 인증 허가 처리 완료");

--- a/src/main/java/com/team1/moim/global/config/security/login/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/team1/moim/global/config/security/login/handler/LoginSuccessHandler.java
@@ -1,5 +1,6 @@
 package com.team1.moim.global.config.security.login.handler;
 
+import com.team1.moim.domain.member.entity.LoginType;
 import com.team1.moim.domain.member.exception.MemberNotFoundException;
 import com.team1.moim.domain.member.repository.MemberRepository;
 import com.team1.moim.global.config.security.jwt.JwtProvider;
@@ -47,6 +48,10 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         memberRepository.findByEmail(email)
                         .ifPresent(member -> {
                             member.updateRefreshToken(refreshToken);
+                            member.updateRepresentativeData(
+                                    member.getEmail(),
+                                    member.getProfileImage(),
+                                    LoginType.NORMAL);
                             memberRepository.saveAndFlush(member);
                         });
 

--- a/src/main/java/com/team1/moim/global/config/security/login/service/LoginService.java
+++ b/src/main/java/com/team1/moim/global/config/security/login/service/LoginService.java
@@ -1,8 +1,9 @@
 package com.team1.moim.global.config.security.login.service;
 
+import com.team1.moim.domain.member.entity.Account;
 import com.team1.moim.domain.member.entity.Member;
-import com.team1.moim.domain.member.exception.MemberNotFoundException;
-import com.team1.moim.domain.member.repository.MemberRepository;
+import com.team1.moim.domain.member.exception.AccountNotFoundException;
+import com.team1.moim.domain.member.repository.AccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -17,7 +18,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class LoginService implements UserDetailsService {
 
-    private final MemberRepository memberRepository;
+    private final AccountRepository accountRepository;
 
     // UserDetails의 User 객체를 만들어서 반환하는 메서드
     // 반환받은 UserDetails 객체의 password를 꺼내어, 내부의 PasswordEncoder에서 password가 일치하는 지 검증 수행
@@ -25,14 +26,15 @@ public class LoginService implements UserDetailsService {
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 
         // DaoAuthenticationProvider가 설정해준 email을 가진 유저를 찾는다.
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(MemberNotFoundException::new);
+        Account findAccount = accountRepository.findByEmail(email).orElseThrow(AccountNotFoundException::new);
+
+        Member findMember = findAccount.getMember();
 
         return User.builder()
-                .username(member.getEmail())
-                .password(member.getPassword())
+                .username(findMember.getEmail())
+                .password(findMember.getPassword())
                 // roles의 메서드를 보면 파라미터로 들어온 role들이 "ROLE_"으로 시작하지 않으면, 예외를 발생시킴
-                .roles(member.getRole().name())
+                .roles(findMember.getRole().name())
                 .build();
     }
 }

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/CustomOAuth2User.java
@@ -1,5 +1,6 @@
 package com.team1.moim.global.config.security.oauth2;
 
+import com.team1.moim.domain.member.entity.LoginType;
 import com.team1.moim.domain.member.entity.Role;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
@@ -11,14 +12,20 @@ import java.util.Map;
 @Getter
 public class CustomOAuth2User extends DefaultOAuth2User {
 
+    private final String nickname;
     private final String email;
+    private final String profileImage;
+    private final LoginType loginType;
     private final Role role;
 
     public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
                             Map<String, Object> attributes, String nameAttributeKey,
-                            String email, Role role){
+                            String nickname, String email, String profileImage, LoginType loginType, Role role){
         super(authorities, attributes, nameAttributeKey);
+        this.nickname = nickname;
         this.email = email;
+        this.profileImage = profileImage;
+        this.loginType = loginType;
         this.role = role;
     }
 }

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/OAuthAttributes.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/OAuthAttributes.java
@@ -2,7 +2,7 @@ package com.team1.moim.global.config.security.oauth2;
 
 import com.team1.moim.domain.member.entity.Member;
 import com.team1.moim.domain.member.entity.Role;
-import com.team1.moim.domain.member.entity.SocialType;
+import com.team1.moim.domain.member.entity.LoginType;
 import com.team1.moim.global.config.security.oauth2.userinfo.GoogleOAuth2UserInfo;
 import com.team1.moim.global.config.security.oauth2.userinfo.KakaoOAuth2UserInfo;
 import com.team1.moim.global.config.security.oauth2.userinfo.OAuth2UserInfo;
@@ -10,7 +10,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.util.Map;
-import java.util.UUID;
 
 /**
  * 각 소셜에서 받아오는 데이터가 다르므로,
@@ -20,8 +19,8 @@ import java.util.UUID;
 @Getter
 public class OAuthAttributes {
 
-    private String nameAttributeKey; // OAuth2 로그인 진행 시 키가 되는 필드 값, PK와 동일
-    private OAuth2UserInfo oAuth2UserInfo; // 소셜 타입별 로그인 유저 정보 (nickname, email, profile_image 등)
+    private final String nameAttributeKey; // OAuth2 로그인 진행 시 키가 되는 필드 값, PK와 동일
+    private final OAuth2UserInfo oAuth2UserInfo; // 소셜 타입별 로그인 유저 정보 (nickname, email, profile_image 등)
 
     @Builder
     private OAuthAttributes(String nameAttributeKey, OAuth2UserInfo oauth2UserInfo){
@@ -34,11 +33,11 @@ public class OAuthAttributes {
      * @param userNameAttributeName: OAuth2 로그인 시 키(PK)가 되는 값
      * @param attributes: OAuth 서비스의 유저 정보들
      */
-    public static OAuthAttributes of(SocialType socialType,
+    public static OAuthAttributes of(LoginType loginType,
                                      String userNameAttributeName,
                                      Map<String, Object> attributes){
 
-        if (socialType == SocialType.GOOGLE) {
+        if (loginType == LoginType.GOOGLE) {
             return ofGoogle(userNameAttributeName, attributes);
         }
 
@@ -61,16 +60,13 @@ public class OAuthAttributes {
                 .build();
     }
 
-    // of메소드로 OAuthAttributes 객체가 생성되어, 유저 정보들이 담긴 OAuth2UserInfo가 소셜 타입별로 주입된 상태
-    public Member toEntity(SocialType socialType, OAuth2UserInfo oAuth2UserInfo){
+    // of 메소드로 OAuthAttributes 객체가 생성되어, 유저 정보들이 담긴 OAuth2UserInfo가 소셜 타입별로 주입된 상태
+    public Member toEntity(OAuth2UserInfo oAuth2UserInfo){
         return Member.builder()
-                .socialType(socialType)
-                .socialId(oAuth2UserInfo.getId())
-                // email은 JWT Token을 발급하기 위한 용도뿐이므로 UUID를 사용하여 임의로 설정
-                .email(UUID.randomUUID() + "@socialMember.com")
+                .email(oAuth2UserInfo.getEmail())
                 .nickname(oAuth2UserInfo.getNickname())
                 .profileImage(oAuth2UserInfo.getImageUrl())
-                .role(Role.USER)
+                .role(Role.GUEST)
                 .build();
     }
 

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,23 +1,24 @@
 package com.team1.moim.global.config.security.oauth2.handler;
 
+import com.team1.moim.domain.member.entity.Member;
+import com.team1.moim.domain.member.entity.Role;
+import com.team1.moim.domain.member.exception.MemberNotFoundException;
 import com.team1.moim.domain.member.repository.MemberRepository;
 import com.team1.moim.global.config.security.jwt.JwtProvider;
 import com.team1.moim.global.config.security.oauth2.CustomOAuth2User;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-
-import java.io.IOException;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtProvider jwtProvider;
     private final MemberRepository memberRepository;
@@ -25,25 +26,50 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
-                                        Authentication authentication) throws IOException, ServletException {
+                                        Authentication authentication) {
         log.info("OAuth2 Login 성공");
+
         try {
             CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
-            loginSuccess(response, oAuth2User); // 로그인에 성공한 경우 access, refresh 토큰 생성
+            Member findMember = memberRepository.findByNickname(oAuth2User.getNickname())
+                    .orElseThrow(MemberNotFoundException::new);
+            String accessToken;
+            String refreshToken;
+
+            if (oAuth2User.getRole() == Role.GUEST){
+                log.info("GUEST 권한이면 토큰 생성 후 USER 권한으로 바꿔줌");
+                accessToken = jwtProvider.createAccessToken(oAuth2User.getNickname(), Role.GUEST.name());
+                refreshToken = jwtProvider.createRefreshToken();
+                findMember.authorizeUser();
+            } else {
+                log.info("USER 권한의 경우");
+                accessToken = jwtProvider.createAccessToken(oAuth2User.getNickname(), oAuth2User.getRole().name());
+                refreshToken = jwtProvider.createRefreshToken();
+            }
+            response.addHeader(jwtProvider.getAccessHeader(), "Bearer " + accessToken);
+            response.addHeader(jwtProvider.getRefreshHeader(), "Bearer " + refreshToken);
+            jwtProvider.sendAccessAndRefreshToken(response, accessToken, refreshToken);
+
+            findMember.updateRepresentativeData(
+                    oAuth2User.getEmail(),
+                    oAuth2User.getProfileImage(),
+                    oAuth2User.getLoginType());
+            findMember.updateRefreshToken(refreshToken);
+            memberRepository.saveAndFlush(findMember);
+
+            log.info("Redirect Strategy 시작");
+
+            String redirectUrl = makeRedirectUrl(accessToken, refreshToken);
+            getRedirectStrategy().sendRedirect(request, response, redirectUrl);
         } catch (Exception e){
             log.error("OAuth2 Login 실패: {}", e.getMessage());
         }
     }
 
-    // 소셜 로그인 시에도 무조건 토큰 생성하지 말고 JWT 인증 필터처럼 RefreshToken 유/무에 따라 다르게 처리
-    private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
-        log.info("loginSuccess 진입");
-        String accessToken = jwtProvider.createAccessToken(oAuth2User.getEmail(), oAuth2User.getRole().name());
-        String refreshToken = jwtProvider.createRefreshToken();
-        response.addHeader(jwtProvider.getAccessHeader(), "Bearer " + accessToken);
-        response.addHeader(jwtProvider.getRefreshHeader(), "Bearer " + refreshToken);
-
-        jwtProvider.sendAccessAndRefreshToken(response, accessToken, refreshToken);
-        jwtProvider.updateRefreshToken(oAuth2User.getEmail(), refreshToken);
+    private String makeRedirectUrl(String accessToken, String refreshToken){
+        return UriComponentsBuilder.fromUriString("http://localhost:8081/oauth2/redirect")
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .build().toUriString();
     }
 }

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/service/CustomOAuth2UserService.java
@@ -1,10 +1,13 @@
 package com.team1.moim.global.config.security.oauth2.service;
 
+import com.team1.moim.domain.member.entity.Account;
 import com.team1.moim.domain.member.entity.Member;
-import com.team1.moim.domain.member.entity.SocialType;
+import com.team1.moim.domain.member.entity.LoginType;
+import com.team1.moim.domain.member.repository.AccountRepository;
 import com.team1.moim.domain.member.repository.MemberRepository;
 import com.team1.moim.global.config.security.oauth2.CustomOAuth2User;
 import com.team1.moim.global.config.security.oauth2.OAuthAttributes;
+import com.team1.moim.global.config.security.oauth2.userinfo.OAuth2UserInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -14,9 +17,11 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @Slf4j
@@ -24,6 +29,7 @@ import java.util.Map;
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private final MemberRepository memberRepository;
+    private final AccountRepository accountRepository;
 
     private static final String KAKAO = "kakao";
 
@@ -31,6 +37,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     // 사용자 정보를 얻은 후, 이를 통해 DefaultOAuth2User 객체를 생성 후 반환
     // 결과적으로, OAuth2User는 OAuth 서비스에서 가져온 유저 정보를 담고 있는 유저
     @Override
+    @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
         log.info("CustomOAuth2UserService.loadUser() 실행 - OAuth2 로그인 요청 진입");
@@ -44,8 +51,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         // http://localhost:8080/oauth2/authorization/kakao에서 kakao가 registrationId
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         log.info("2");
-        SocialType socialType = getSocialType(registrationId);
-        log.info("3 / socialType: {}", socialType);
+        LoginType loginType = getSocialType(registrationId);
+        log.info("3 / socialType: {}", loginType);
         String userNameAttributeName = userRequest.getClientRegistration()
                 .getProviderDetails()
                 .getUserInfoEndpoint()
@@ -57,46 +64,78 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         log.info("5 / attributes: {}", attributes);
 
         // SocialType에 따라 유저 정보를 통해 OAuthAttributes 객체 생성
-        OAuthAttributes extractAttributes = OAuthAttributes.of(socialType, userNameAttributeName, attributes);
+        OAuthAttributes extractAttributes = OAuthAttributes.of(loginType, userNameAttributeName, attributes);
         log.info("6 / extractAttributes: {}", extractAttributes);
 
-        Member createdMember = getMember(extractAttributes, socialType);
+        Member createdMember = getMember(extractAttributes, loginType);
         log.info("7 / createdMember: {}", createdMember);
 
         return new CustomOAuth2User(
                 Collections.singleton(new SimpleGrantedAuthority(createdMember.getRole().name())),
                 attributes,
                 extractAttributes.getNameAttributeKey(),
+                createdMember.getNickname(),
                 createdMember.getEmail(),
+                createdMember.getProfileImage(),
+                createdMember.getLoginType(),
                 createdMember.getRole());
     }
 
-    private SocialType getSocialType(String registrationId) {
+    private LoginType getSocialType(String registrationId) {
         if (registrationId.equals(KAKAO)){
-            return SocialType.KAKAO;
+            return LoginType.KAKAO;
         }
-        return SocialType.GOOGLE;
+        return LoginType.GOOGLE;
     }
 
     // SocialType과 attributes에 들어있는 소셜 로그인의 식별값 id를 통해 회원을 찾아 반환
     // 만약 찾은 회원이 있다면 그대로 반환하고, 없다면 saveUser()를 호출하여 회원을 저장
-    private Member getMember(OAuthAttributes attributes, SocialType socialType){
-        Member findMember = memberRepository.findBySocialTypeAndSocialId(socialType,
+    private Member getMember(OAuthAttributes attributes, LoginType loginType){
+
+        log.info("소셜 로그인 유저의 닉네임이 DB에 이미 존재한다면 ");
+        log.info("DB에 소셜 로그인 회원 있는지 확인!!");
+
+        Account account = accountRepository.findByLoginTypeAndSocialId(loginType,
                 attributes.getOAuth2UserInfo().getId()).orElse(null);
 
-        if (findMember == null){
-            return saveMember(attributes, socialType);
+        if (account == null){
+            log.info("신규 소셜 로그인 계정이므로 DB에 저장해주기!");
+            return saveMember(attributes, loginType);
         }
 
-        return findMember;
+        account.getMember().updateRepresentativeData(
+                attributes.getOAuth2UserInfo().getEmail(),
+                attributes.getOAuth2UserInfo().getImageUrl(),
+                loginType
+        );
+
+        return memberRepository.save(account.getMember());
     }
 
     // 생성된 Member 객체를 DB에 저장 : socialType, socialId, email, role 값만 있는 상태
-    private Member saveMember(OAuthAttributes attributes, SocialType socialType){
+    private Member saveMember(OAuthAttributes attributes, LoginType loginType){
 
-        Member createdMember = attributes.toEntity(socialType, attributes.getOAuth2UserInfo());
+        OAuth2UserInfo oAuth2UserInfo = attributes.getOAuth2UserInfo();
+        Account account = Account.builder()
+                .email(oAuth2UserInfo.getEmail())
+                .profileImage(oAuth2UserInfo.getImageUrl())
+                .socialId(oAuth2UserInfo.getId())
+                .loginType(loginType)
+                .build();
+
+        Optional<Member> optionalMember = memberRepository.findByNickname(oAuth2UserInfo.getNickname());
+        if (optionalMember.isPresent()){
+            Member findMember = optionalMember.get();
+            account.attachMember(findMember);
+            log.info("{}과 동일한 닉네임의 유저가 이미 있습니다!", findMember.getNickname());
+            findMember.getAccounts().add(account);
+            findMember.updateRepresentativeData(account.getEmail(), account.getProfileImage(), loginType);
+            return memberRepository.save(findMember);
+        }
+        Member createdMember = attributes.toEntity(attributes.getOAuth2UserInfo());
+        account.attachMember(createdMember);
+        log.info("{} 소셜 로그인 회원이 DB에 저장됩니다. ", createdMember.getNickname());
 
         return memberRepository.save(createdMember);
     }
-
 }

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/userinfo/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/userinfo/GoogleOAuth2UserInfo.java
@@ -22,4 +22,8 @@ public class GoogleOAuth2UserInfo extends OAuth2UserInfo{
     public String getImageUrl() {
         return (String) attributes.get("picture");
     }
+    @Override
+    public String getEmail(){
+        return (String) attributes.get("email");
+    }
 }

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/userinfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/userinfo/KakaoOAuth2UserInfo.java
@@ -1,7 +1,10 @@
 package com.team1.moim.global.config.security.oauth2.userinfo;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.Map;
 
+@Slf4j
 public class KakaoOAuth2UserInfo extends OAuth2UserInfo{
 
     public KakaoOAuth2UserInfo(Map<String, Object> attributes){
@@ -47,5 +50,16 @@ public class KakaoOAuth2UserInfo extends OAuth2UserInfo{
         }
 
         return (String) profile.get("thumbnail_image_url");
+    }
+    @Override
+    public String getEmail() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+
+        log.info("카카오에서 가져온 계정 정보: {}", account);
+        if (account == null) {
+            return null;
+        }
+
+        return (String) account.get("email");
     }
 }

--- a/src/main/java/com/team1/moim/global/config/security/oauth2/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/com/team1/moim/global/config/security/oauth2/userinfo/OAuth2UserInfo.java
@@ -18,4 +18,5 @@ public abstract class OAuth2UserInfo {
     public abstract String getId(); // 소셜 식별 값 : 구글 - "sub", 카카오 - "id"
     public abstract String getNickname();
     public abstract String getImageUrl();
+    public abstract String getEmail();
 }

--- a/src/main/java/com/team1/moim/global/exception/ErrorCode.java
+++ b/src/main/java/com/team1/moim/global/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 이메일입니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 계정입니다."),
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
     MEMBER_NOT_MATCH(HttpStatus.BAD_REQUEST, "회원이 일치하지 않습니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈 (이슈 잘못 연결함.. 실수로 #75 로 연결해버림)
* #113 

## 📝작업한 내용
1. 구글, 카카오 로그인 프론트와 연동
2. Member의 Unique 데이터를 이메일에서 닉네임으로 수정
3. 동일 닉네임의 소셜 계정으로 로그인 하면 하나의 Member에 연동

## 증거
1. 구글 로그인
<img width="1361" alt="스크린샷 2024-04-27 오후 11 47 54" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/60949121/4bc0dbea-222e-4652-b7af-34b34cb7bef4">

2. 카카오 로그인
<img width="1351" alt="스크린샷 2024-04-27 오후 11 49 30" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/60949121/28a1da40-c90b-49ae-953b-cd3932950d1a">

3. 하나의 member에 구글, 카카오 계정(동일 닉네임) 연동
<img width="1026" alt="스크린샷 2024-04-27 오후 11 50 29" src="https://github.com/HanHwa-Team1-Final-Project/MOIM-BE/assets/60949121/7d139cbe-fd14-44fd-b6cd-1737469f1854">
 


## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정
- [x] 기능 추가
- [x] 코드 스타일 변경 (formatting, local variables)
- [x] 리팩토링 (기능 변경 X)