### PR TITLE
[Fix/Login] 일반 로그인 에러 해결(#116)

### DIFF
--- a/src/main/java/com/team1/moim/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/team1/moim/global/config/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.team1.moim.global.config.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team1.moim.domain.member.repository.AccountRepository;
 import com.team1.moim.domain.member.repository.MemberRepository;
 import com.team1.moim.global.config.security.jwt.JwtAuthenticationProcessingFilter;
 import com.team1.moim.global.config.security.jwt.JwtProvider;
@@ -56,6 +57,7 @@ public class SecurityConfig {
     private final LoginService loginService;
     private final JwtProvider jwtProvider;
     private final MemberRepository memberRepository;
+    private final AccountRepository accountRepository;
     private final ObjectMapper objectMapper;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
@@ -132,7 +134,7 @@ public class SecurityConfig {
 
     @Bean
     public LoginSuccessHandler loginSuccessHandler() {
-        return new LoginSuccessHandler(jwtProvider, memberRepository);
+        return new LoginSuccessHandler(jwtProvider, memberRepository, accountRepository);
     }
 
     @Bean

--- a/src/main/java/com/team1/moim/global/config/security/jwt/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/team1/moim/global/config/security/jwt/JwtAuthenticationProcessingFilter.java
@@ -36,7 +36,6 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
     // 아래 url로 들어오는 요청은 Filter 작동 X
     private static final String[] NO_CHECK_URLS = {
-            "/",
             "/login",
             "/oauth2/authorize/google",
             "/oauth2/authorize/kakao",

--- a/src/main/java/com/team1/moim/global/config/security/jwt/JwtProvider.java
+++ b/src/main/java/com/team1/moim/global/config/security/jwt/JwtProvider.java
@@ -55,12 +55,12 @@ public class JwtProvider {
      * AccessToken 생성 메서드
      * Payload에 email과 role 정보 넣어서 생성
      */
-    public String createAccessToken(String email, String role){
+    public String createAccessToken(String nickname, String role){
         Date now = new Date();
         return JWT.create() // JWT 토큰을 생성하는 빌더 생성
                 .withSubject(ACCESS_TOKEN_SUBJECT)
                 .withExpiresAt(new Date(now.getTime() + accessTokenExpiration))
-                .withClaim(NICKNAME_CLAIM, email) // 사용자 정의 클레임
+                .withClaim(NICKNAME_CLAIM, nickname) // 사용자 정의 클레임
                 .withClaim(ROLE_CLAIM, role)
                 .sign(Algorithm.HMAC512(secretKey)); // HMAC512 알고리즘 사용하여 secret 키로 암호화
     }

--- a/src/main/java/com/team1/moim/global/config/security/login/filter/CustomJsonUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/com/team1/moim/global/config/security/login/filter/CustomJsonUsernamePasswordAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.team1.moim.global.config.security.login.filter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -19,6 +20,7 @@ import java.util.Map;
  * Spring Security Form Login 기반의 UsernamePasswordAuthenticationFilter를 참고하여 만든 커스텀 필터
  * "/login" 요청 왔을 때, JSON 값을 매핑 처리하는 필터 작동
  */
+@Slf4j
 public class CustomJsonUsernamePasswordAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
 
     private static final String DEFAULT_LOGIN_REQUEST_URL = "/login"; // "/login"으로 오는 요청을 처리
@@ -47,6 +49,7 @@ public class CustomJsonUsernamePasswordAuthenticationFilter extends AbstractAuth
     public Authentication attemptAuthentication(HttpServletRequest request,
                                                 HttpServletResponse response)
                                                     throws AuthenticationException, IOException {
+        log.info("1. attemptAuthentication 진입");
         if (request.getContentType() == null || !request.getContentType().equals(CONTENT_TYPE)) {
             throw new AuthenticationServiceException("Authentication Content-Type not supported: "
                                                         + request.getContentType());
@@ -56,9 +59,11 @@ public class CustomJsonUsernamePasswordAuthenticationFilter extends AbstractAuth
         // 요청 JSON example
         //  {"email" : "user@naver.com", "password" : "user1234@"}
         String messageBody = StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8);
+        log.info("2. 요청 헤더의 Message Body: {}", messageBody);
 
         // 꺼낸 messageBody를 objectMapper.readValue()로 Map으로 변환 (Key : JSON의 키 -> email, password)
         Map<String, String> usernamePasswordMap = objectMapper.readValue(messageBody, Map.class);
+        log.info("3. usernamePasswordMap: {}", usernamePasswordMap);
 
         // Map의 Key(email, password)로 해당 이메일, 패스워드 추출
         String email = usernamePasswordMap.get(USERNAME_KEY);
@@ -70,6 +75,7 @@ public class CustomJsonUsernamePasswordAuthenticationFilter extends AbstractAuth
         // DaoAuthenticationProvider는 UserDetailsService의 loadUserByUsername을 호출하여
         // UserDetails 객체를 반환 받음 -> LoginService에서 추가 설명
         UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(email, password);
+        log.info("4. authRequest: {}", authRequest);
 
         return this.getAuthenticationManager().authenticate(authRequest);
     }

--- a/src/main/java/com/team1/moim/global/config/security/login/service/LoginService.java
+++ b/src/main/java/com/team1/moim/global/config/security/login/service/LoginService.java
@@ -5,17 +5,20 @@ import com.team1.moim.domain.member.entity.Member;
 import com.team1.moim.domain.member.exception.AccountNotFoundException;
 import com.team1.moim.domain.member.repository.AccountRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 커스텀 로그인 서비스
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class LoginService implements UserDetailsService {
 
     private final AccountRepository accountRepository;
@@ -23,12 +26,17 @@ public class LoginService implements UserDetailsService {
     // UserDetails의 User 객체를 만들어서 반환하는 메서드
     // 반환받은 UserDetails 객체의 password를 꺼내어, 내부의 PasswordEncoder에서 password가 일치하는 지 검증 수행
     @Override
+    @Transactional
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 
+        log.info("1. loadUserByUsername 진입!");
         // DaoAuthenticationProvider가 설정해준 email을 가진 유저를 찾는다.
+
         Account findAccount = accountRepository.findByEmail(email).orElseThrow(AccountNotFoundException::new);
+        log.info("2. findAccount - Email: {}", findAccount.getEmail());
 
         Member findMember = findAccount.getMember();
+        log.info("3. findMember - email: {}, nickname: {}", findMember.getEmail(), findMember.getNickname());
 
         return User.builder()
                 .username(findMember.getEmail())


### PR DESCRIPTION
## #️⃣연관된 이슈
* #116 

## 📝작업한 내용
1. 에러: could not initialize proxy - no session
2. 원인
  - 1:N 관계의 Account Entity의 Member 객체의 Fetch 전략을 Lazy(지연 로딩)로 설정함
  - Account를 통해 조회한 Member 객체는 바로 초기화 되지 않고, 필요할 때 정보가 채워지는 프록시 객체로 채워짐.
  - JPA 영속성 컨텍스트는 트랜잭션과 생명주기를 함께하므로 Account를 통해 Member를 조회하는 메서드 상단에 @Transactional을 붙여줘야 함
3. _**해결 방안: onAuthenticationSuccess()와 LoginService()에 @Transactional 적용**_

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정