### PR TITLE
레디스에 해당 모임id의 추천일정이 이미 있으면 추천일정을 담지 않도록 수정

### DIFF
--- a/src/main/java/com/team1/moim/domain/group/service/GroupService.java
+++ b/src/main/java/com/team1/moim/domain/group/service/GroupService.java
@@ -172,7 +172,10 @@ public class GroupService {
                     log.info("추천 일정: " + recommendEvents);
                     recommendEvents.forEach(recommendEvent -> {
                         try {
-                            redisService.setAvailableList(group.getId().toString(), recommendEvent);
+//                            if (!recommendEvents.contains(recommendEvent)) {
+                            if (redisService.getAvailableList(String.valueOf(group.getId())).isEmpty()) {
+                                redisService.setAvailableList(group.getId().toString(), recommendEvent);
+                            }
                         } catch (Exception e) {
                             throw new RuntimeException(e);
                         }
@@ -373,7 +376,8 @@ public class GroupService {
                     List<AvailableResponse> existingEvents = redisService.getAvailableList(groupId.toString());
 
                     // 추천된 이벤트가 리스트에 이미 있는지 확인합니다
-                    if (!existingEvents.contains(recommendEvent)) {
+//                    if (!existingEvents.contains(recommendEvent)) {
+                        if (redisService.getAvailableList(groupId.toString()).isEmpty()) {
                         // 이벤트가 없을 경우 Redis에 추가합니다
                         redisService.setAvailableList(groupId.toString(), recommendEvent);
                     }


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) * 

## 📝작업한 내용
>  
- vote, scheduleGroupAlarm 메소드 내에서 추천일정을 담을때 레디스의 해당 그룹id(key)에 해당하는 추천일정(value)이 있다면 아예 값을 넣지 않게 수정
- 근데 레디스 코드 첨해봐서 이게 맞는지 확실하지 않음 (도와줘 소영쟈귀...... )
"176번줄, 380번줄의 redisService.getAvailableList " 이부분에서 group.id로 찾게 했는데 이게 맞는지 확실하지 않아유 
- 주의 해야할것: 추천일정이 레디스 2번채널? 에 담겨있어서 그걸 비우지 않고 데이터베이스만 지웠다가 
같은 모임 id에서 추천일정 만들면 전의 추천일정만 담기게 됨 (나 이거 2시간 동안,,,, 찾았,,, ㅇㅇㅇ광광... 나는 똥멍청이야,,,,,)