### PR TITLE
Eunji/today list

### DIFF
--- a/src/main/java/com/team1/moim/domain/event/controller/EventController.java
+++ b/src/main/java/com/team1/moim/domain/event/controller/EventController.java
@@ -7,6 +7,7 @@ import com.team1.moim.domain.event.dto.request.RepeatRequest;
 import com.team1.moim.domain.event.dto.request.ToDoListRequest;
 import com.team1.moim.domain.event.dto.response.AlarmResponse;
 import com.team1.moim.domain.event.dto.response.EventResponse;
+import com.team1.moim.domain.event.dto.response.TodayEventResponse;
 import com.team1.moim.domain.event.dto.response.TodoResponse;
 import com.team1.moim.domain.event.entity.Matrix;
 import com.team1.moim.domain.event.entity.ToDoList;
@@ -208,10 +209,10 @@ public class EventController {
 //    일별 조회
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/daily/{year}/{month}/{day}")
-    public ResponseEntity<ApiSuccessResponse<List<EventResponse>>> getDaily(HttpServletRequest httpServletRequest,
-                                                                             @PathVariable("year") int year,
-                                                                             @PathVariable("month") int month,
-                                                                             @PathVariable("day") int day) {
+    public ResponseEntity<ApiSuccessResponse<List<TodayEventResponse>>> getDaily(HttpServletRequest httpServletRequest,
+                                                                                 @PathVariable("year") int year,
+                                                                                 @PathVariable("month") int month,
+                                                                                 @PathVariable("day") int day) {
         log.info("일별 조회 시작");
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/team1/moim/domain/event/dto/response/TodayEventResponse.java
+++ b/src/main/java/com/team1/moim/domain/event/dto/response/TodayEventResponse.java
@@ -1,0 +1,49 @@
+package com.team1.moim.domain.event.dto.response;
+
+import com.team1.moim.domain.event.entity.Event;
+import com.team1.moim.domain.event.entity.Matrix;
+import com.team1.moim.domain.event.entity.ToDoList;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class TodayEventResponse {
+    private Long id;
+    private String nickname;
+    private String title;
+    private String memo;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private String place;
+    private Matrix matrix;
+    private String fileUrl;
+    private String deleteYn;
+    private Long repeatParent;
+    private String alarmYn;
+    private List<String[]> todoLists;
+
+//    private List<AlarmResponse> alarms;
+
+    public static TodayEventResponse from(Event event, List<String[]> todoLists){
+        return TodayEventResponse.builder()
+                .id(event.getId())
+                .title(event.getTitle())
+                .memo(event.getMemo())
+                .startDate(event.getStartDateTime())
+                .endDate(event.getEndDateTime())
+                .place(event.getPlace())
+                .matrix(event.getMatrix())
+                .fileUrl(event.getFileUrl())
+                .deleteYn(event.getDeleteYn())
+                .repeatParent(event.getRepeatParent())
+                .alarmYn(event.getAlarmYn())
+                .nickname(event.getMember().getNickname())
+                .todoLists(todoLists)
+                .build();
+    }
+
+}

--- a/src/main/java/com/team1/moim/domain/event/service/EventService.java
+++ b/src/main/java/com/team1/moim/domain/event/service/EventService.java
@@ -37,6 +37,7 @@ import java.time.LocalDateTime;
 import java.time.chrono.ChronoLocalDate;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -461,6 +462,7 @@ public class EventService {
             TodayEventResponse eventResponse = TodayEventResponse.from(event, eventTodoList);
             todayEventResponses.add(eventResponse);
         }
+        Collections.sort(todayEventResponses, Comparator.comparing(TodayEventResponse::getStartDate));
 
         return todayEventResponses;
     }

--- a/src/main/java/com/team1/moim/domain/event/service/EventService.java
+++ b/src/main/java/com/team1/moim/domain/event/service/EventService.java
@@ -7,6 +7,7 @@ import com.team1.moim.domain.event.dto.request.RepeatRequest;
 import com.team1.moim.domain.event.dto.request.ToDoListRequest;
 import com.team1.moim.domain.event.dto.response.AlarmResponse;
 import com.team1.moim.domain.event.dto.response.EventResponse;
+import com.team1.moim.domain.event.dto.response.TodayEventResponse;
 import com.team1.moim.domain.event.dto.response.TodoResponse;
 import com.team1.moim.domain.event.entity.Alarm;
 import com.team1.moim.domain.event.entity.AlarmType;
@@ -439,19 +440,29 @@ public class EventService {
         return eventResponses;
     }
 
-    public List<EventResponse> getDaily(int year, int month, int day) {
+    public List<TodayEventResponse> getDaily(int year, int month, int day) {
         Member member = findMemberByEmail();
         log.info(member.getNickname() + "님 일정 조회");
         List<Event> events = eventRepository.findByMemberAndYearAndMonthAndDay(member, year, month, day);
         if (events.isEmpty()) throw new EventNotFoundException();
-        List<EventResponse> eventResponses = new ArrayList<>();
+        List<TodayEventResponse> todayEventResponses = new ArrayList<>();
         for (Event event : events) {
             log.info(event.getTitle());
-            EventResponse eventResponse = EventResponse.from(event);
-            eventResponses.add(eventResponse);
+            List<ToDoList> toDoLists = toDoListRepository.findByEventId(event.getId());
+            List<String[]> eventTodoList = new ArrayList<>();
+
+            for(ToDoList toDoList: toDoLists){
+                String[] tempTodoList = new String[3];
+                tempTodoList[0] = String.valueOf(toDoList.getId());
+                tempTodoList[1] = toDoList.getContents();
+                tempTodoList[2] = toDoList.getIsChecked();
+                eventTodoList.add(tempTodoList);
+            }
+            TodayEventResponse eventResponse = TodayEventResponse.from(event, eventTodoList);
+            todayEventResponses.add(eventResponse);
         }
 
-        return eventResponses;
+        return todayEventResponses;
     }
 
     public EventResponse getEvent(Long eventId) {

--- a/src/main/java/com/team1/moim/domain/group/controller/GroupController.java
+++ b/src/main/java/com/team1/moim/domain/group/controller/GroupController.java
@@ -5,11 +5,7 @@ import com.team1.moim.domain.event.dto.response.AvailableResponse;
 import com.team1.moim.domain.group.dto.request.GroupAlarmRequest;
 import com.team1.moim.domain.group.dto.request.GroupInfoRequest;
 import com.team1.moim.domain.group.dto.request.GroupRequest;
-import com.team1.moim.domain.group.dto.response.FindConfirmedGroupResponse;
-import com.team1.moim.domain.group.dto.response.FindPendingGroupResponse;
-import com.team1.moim.domain.group.dto.response.GroupDetailResponse;
-import com.team1.moim.domain.group.dto.response.ListGroupResponse;
-import com.team1.moim.domain.group.dto.response.VoteResponse;
+import com.team1.moim.domain.group.dto.response.*;
 import com.team1.moim.domain.group.service.GroupService;
 import com.team1.moim.global.dto.ApiSuccessResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -194,6 +190,18 @@ public class GroupController {
                         groupService.findGroup(groupId)));
     }
 
-
+    // 모임 조회(모든 타입)
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/today")
+    public ResponseEntity<ApiSuccessResponse<List<TodayGroupResponse>>> today(
+            HttpServletRequest httpServletRequest) {
+        log.info("오늘의 확정 모임 조회");
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiSuccessResponse.of(
+                        HttpStatus.OK,
+                        httpServletRequest.getServletPath(),
+                        groupService.todayGroup()));
+    }
 
 }

--- a/src/main/java/com/team1/moim/domain/group/dto/response/TodayGroupResponse.java
+++ b/src/main/java/com/team1/moim/domain/group/dto/response/TodayGroupResponse.java
@@ -1,0 +1,61 @@
+package com.team1.moim.domain.group.dto.response;
+
+import com.team1.moim.domain.group.entity.Group;
+import com.team1.moim.domain.group.entity.GroupType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class TodayGroupResponse {
+    private Long id;
+    private String hostNickname;
+    private String isConfirmed;
+    private String title;
+    private String place;
+    private LocalDate expectStartDate;
+    private LocalDate expectEndDate;
+    private LocalTime expectStartTime;
+    private LocalTime expectEndTime;
+    private LocalDateTime voteDeadline;
+    private String contents;
+    private String filePath;
+    private int participants;
+    private GroupType groupType;
+    private int runningTime;
+    private LocalDateTime confirmedDateTime;
+    private List<GroupInfoResponse> groupInfos;
+
+    public static TodayGroupResponse from(Group group) {
+
+        List<GroupInfoResponse> groupInfos = group.getGroupInfos().stream()
+                .map(GroupInfoResponse::from)
+                .collect(Collectors.toList());
+
+        return TodayGroupResponse.builder()
+                .id(group.getId())
+                .hostNickname(group.getMember().getNickname())
+                .isConfirmed(group.getIsConfirmed())
+                .title(group.getTitle())
+                .place(group.getPlace())
+                .expectStartDate(group.getExpectStartDate())
+                .expectEndDate(group.getExpectEndDate())
+                .expectStartTime(group.getExpectStartTime())
+                .expectEndTime(group.getExpectEndTime())
+                .voteDeadline(group.getVoteDeadline())
+                .contents(group.getContents())
+                .filePath(group.getFilePath())
+                .participants(group.getParticipants())
+                .groupType(group.getGroupType())
+                .runningTime(group.getRunningTime())
+                .groupInfos(groupInfos)
+                .confirmedDateTime(group.getConfirmedDateTime())
+                .build();
+    }
+}

--- a/src/main/java/com/team1/moim/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/team1/moim/domain/group/repository/GroupRepository.java
@@ -3,6 +3,8 @@ package com.team1.moim.domain.group.repository;
 import com.team1.moim.domain.group.entity.Group;
 import java.util.List;
 import java.util.Optional;
+
+import com.team1.moim.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -26,5 +28,6 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
 
     List<Group> findByMemberId(Long memberId);
 
+    List<Group> findByIsConfirmedAndMember(String isConfirmed, Member member);
 
 }

--- a/src/main/java/com/team1/moim/domain/group/service/GroupService.java
+++ b/src/main/java/com/team1/moim/domain/group/service/GroupService.java
@@ -750,7 +750,7 @@ public class GroupService {
         for(Group group: allTodayGroup){
             todayGroupResponses.add(TodayGroupResponse.from(group));
         }
-
+        Collections.sort(todayGroupResponses, Comparator.comparing(TodayGroupResponse::getConfirmedDateTime));
         return todayGroupResponses;
 
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) * #이슈번호

## 📝작업한 내용
> 
- 오늘의 확정 모임 api추가
 - 일별조회 수정 - EventResponse를 TodayEventResponse로 변경
 
- 일별조회, 모임 조회 날짜 순서대로 나오도록 변경
