### PR TITLE
[Fix] 로그인과 회원가입 화면에서 입력되는 항목의 제약사항 추가

### DIFF
--- a/src/main/java/com/team1/moim/domain/member/entity/Member.java
+++ b/src/main/java/com/team1/moim/domain/member/entity/Member.java
@@ -19,7 +19,7 @@ public class Member extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true, nullable = false, length=254)
     private String email; // 대표 이메일
 
     // 소셜 로그인 유저의 경우 비밀번호가 필요 없으므로, nullable


### PR DESCRIPTION
- 이메일 주소의 최대 길이는 RFC 5321에 따라서 도메인 이름과 로컬 파트를 포함해 254자 이하까지만 가능하도록 제한.

## #️⃣연관된 이슈
> ex) * #이슈번호

## 📝작업한 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경 (formatting, local variables)
- [ ] 리팩토링 (기능 변경 X)
- [ ] 빌드 관련 수정
- [ ] 문서 내용 수정
- [ ] 테스트 추가
- [ ] 그 외, 어떤 종류인지 기입 바람:

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
