### PR TITLE
[Fix] Room 엔티티에 글자 수 제한 추가

### DIFF
--- a/src/main/java/com/team1/moim/domain/chat/entity/Room.java
+++ b/src/main/java/com/team1/moim/domain/chat/entity/Room.java
@@ -2,8 +2,16 @@ package com.team1.moim.domain.chat.entity;
 
 import com.team1.moim.domain.member.entity.Member;
 import com.team1.moim.global.config.BaseTimeEntity;
-import jakarta.persistence.*;
-
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -11,7 +19,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Getter
@@ -27,10 +34,11 @@ public class Room extends BaseTimeEntity {
     private Member member;
 
     // 채팅방의 이름
-    @Column(nullable = false)
+    @Column(nullable = false, length = 50)
     private String title;
 
     // 채팅방 메모
+    @Column(length = 100)
     private String memo;
 
     // 채팅방 삭제일


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) * #이슈번호

## 📝작업한 내용

- Room entity의 title은 50자, memo는 100자까지 길이를 지정

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경 (formatting, local variables)
- [ ] 리팩토링 (기능 변경 X)
- [ ] 빌드 관련 수정
- [ ] 문서 내용 수정
- [ ] 테스트 추가
- [ ] 그 외, 어떤 종류인지 기입 바람:

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
